### PR TITLE
Refactor SEO handling into dedicated component

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -13,10 +13,22 @@ export default defineConfig({
   integrations: [
     react(),
     sitemap({
-      filter: (page) => !page.startsWith("/drafts"),
+      filter: (page) => !new URL(page).pathname.startsWith("/drafts"),
       changefreq: "weekly",
       priority: 0.7,
-      lastmod: new Date(),
+      serialize(item) {
+        const { pathname } = new URL(item.url);
+
+        if (pathname === "/") {
+          item.priority = 1.0;
+        } else if (pathname.startsWith("/cours")) {
+          item.priority = 0.9;
+        } else if (pathname === "/mentions-legales/") {
+          item.priority = 0.3;
+        }
+
+        return item;
+      },
     }),
     db(),
   ],

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -1,0 +1,173 @@
+---
+import type { Breadcrumb } from "../types/Breadcrumb";
+
+interface Props {
+  title?: string;
+  description?: string;
+  image?: string;
+  imageAlt?: string;
+  pageType?: "website" | "article";
+  pubDate?: string;
+  author?: string;
+  noindex?: boolean;
+  breadcrumbs?: Breadcrumb[];
+  /** Donnees structurees additionnelles (ex: Course) a injecter en JSON-LD. */
+  schemas?: Record<string, unknown>[];
+}
+
+const SITE_URL = "https://nx.academy";
+const SITE_NAME = "NX Academy";
+const DEFAULT_TITLE =
+  "Passez au niveau supérieur en programmation avec NX Academy";
+const DEFAULT_DESCRIPTION =
+  "Avec NX Academy, suivez gratuitement des cours en ligne et améliorez vos compétences en programmation et devops. Aucun compte n'est requis.";
+const DEFAULT_IMAGE = "/images/misc/vendeur-journaux.webp";
+
+const {
+  title: rawTitle,
+  description: rawDescription,
+  image: rawImage,
+  imageAlt,
+  pageType = "website",
+  pubDate,
+  author,
+  noindex = false,
+  breadcrumbs,
+  schemas = [],
+} = Astro.props;
+
+const { pathname } = Astro.url;
+
+const pageTitle = rawTitle ? rawTitle : null;
+const title = pageTitle ? `${pageTitle} - ${SITE_NAME}` : DEFAULT_TITLE;
+const description = rawDescription ? rawDescription : DEFAULT_DESCRIPTION;
+const image = `${SITE_URL}${rawImage ? rawImage : DEFAULT_IMAGE}`;
+const canonicalURL = `${SITE_URL}${pathname}`;
+
+// Date de publication au format ISO 8601 (pour Open Graph + JSON-LD).
+let publishedISO: string | undefined;
+if (pubDate) {
+  const parsed = new Date(pubDate);
+  if (!Number.isNaN(parsed.getTime())) {
+    publishedISO = parsed.toISOString();
+  }
+}
+
+// --- Donnees structurees (Schema.org / JSON-LD) ---
+const organization = {
+  "@type": "Organization",
+  "@id": `${SITE_URL}/#organization`,
+  name: SITE_NAME,
+  url: SITE_URL,
+  logo: `${SITE_URL}/favicons/android-chrome-512x512.png`,
+  sameAs: [
+    "https://github.com/nx-academy",
+    "https://www.linkedin.com/company/nx-academy-france",
+  ],
+};
+
+const jsonLdGraph: Record<string, unknown>[] = [organization];
+
+// WebSite uniquement sur la page d'accueil.
+if (pathname === "/") {
+  jsonLdGraph.push({
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    name: SITE_NAME,
+    url: SITE_URL,
+    inLanguage: "fr-FR",
+    publisher: { "@id": `${SITE_URL}/#organization` },
+  });
+}
+
+// Fil d'Ariane : on reprend les ancetres + la page courante.
+if (breadcrumbs && breadcrumbs.length > 0) {
+  const items = breadcrumbs.map((crumb, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    name: crumb.pageName,
+    item: `${SITE_URL}${crumb.pageUrl}`,
+  }));
+
+  if (pageTitle) {
+    items.push({
+      "@type": "ListItem",
+      position: items.length + 1,
+      name: pageTitle,
+      item: canonicalURL,
+    });
+  }
+
+  jsonLdGraph.push({
+    "@type": "BreadcrumbList",
+    itemListElement: items,
+  });
+}
+
+// Article / BlogPosting pour les contenus editoriaux.
+if (pageType === "article" && pageTitle) {
+  jsonLdGraph.push({
+    "@type": "BlogPosting",
+    headline: pageTitle,
+    description,
+    image,
+    ...(author ? { author: { "@type": "Person", name: author } } : {}),
+    ...(publishedISO
+      ? { datePublished: publishedISO, dateModified: publishedISO }
+      : {}),
+    mainEntityOfPage: { "@type": "WebPage", "@id": canonicalURL },
+    publisher: { "@id": `${SITE_URL}/#organization` },
+    inLanguage: "fr-FR",
+  });
+}
+
+// Schemas additionnels fournis par la page (ex: Course).
+for (const schema of schemas) {
+  jsonLdGraph.push(schema);
+}
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": jsonLdGraph,
+};
+---
+
+<title>{title}</title>
+<meta name="description" content={description} />
+<link rel="canonical" href={canonicalURL} />
+
+{noindex && <meta name="robots" content="noindex, follow" />}
+
+<!-- Open Graph -->
+<meta property="og:type" content={pageType} />
+<meta property="og:site_name" content={SITE_NAME} />
+<meta property="og:locale" content="fr_FR" />
+<meta property="og:url" content={canonicalURL} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={image} />
+{imageAlt && <meta property="og:image:alt" content={imageAlt} />}
+{
+  pageType === "article" && publishedISO && (
+    <meta property="article:published_time" content={publishedISO} />
+  )
+}
+{
+  pageType === "article" && author && (
+    <meta property="article:author" content={author} />
+  )
+}
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={image} />
+{imageAlt && <meta name="twitter:image:alt" content={imageAlt} />}
+
+<!-- Donnees structurees -->
+<script
+  type="application/ld+json"
+  set:html={JSON.stringify(jsonLd)}
+  is:inline
+/>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,7 +6,12 @@ interface Props {
   description?: string
   breadcrumbs?: Breadcrumb[]
   image?: string
+  imageAlt?: string
   pubDate?: string
+  pageType?: "website" | "article"
+  author?: string
+  noindex?: boolean
+  schemas?: Record<string, unknown>[]
 }
 
 import "@fontsource/pixelify-sans";
@@ -18,21 +23,17 @@ import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
 import ResumeSnackbar from "../components/ResumeSnackbar"
 import ScrollToTopButton from "../components/ScrollToTopButton.astro"
+import Seo from "../components/Seo.astro"
 import SvgIcons from "../components/SvgIcons.astro"
 
-let { title, description, breadcrumbs, image, pubDate } = Astro.props
+const { title, description, breadcrumbs, image, imageAlt, pubDate, pageType, author, noindex, schemas } = Astro.props
 const { pathname } = Astro.url
-
-title = title ? `${title} - NX Academy` : "Passez au niveau supérieur en programmation avec NX Academy"
-description = description ? description : "Avec NX Academy, suivez gratuitement des cours en ligne et améliorez vos compétences en programmation et devops. Aucun compte n'est requis."
-image = image ? `https://nx.academy${image}` : "https://nx.academy/vendeur-journaux.webp"
-pubDate = pubDate ? new Date(pubDate).toLocaleDateString('fr-FR') : new Date().toLocaleDateString("fr-FR")
 ---
 
-<html lang="FR-fr">
+<html lang="fr">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
@@ -41,9 +42,19 @@ pubDate = pubDate ? new Date(pubDate).toLocaleDateString('fr-FR') : new Date().t
     <link rel="manifest" href="/favicons/site.webmanifest">
 
     <link rel="sitemap" href="/sitemap-index.xml" />
-    
-    <title>{title}</title>
-    <meta name="description" content={description}>
+
+    <Seo
+      title={title}
+      description={description}
+      image={image}
+      imageAlt={imageAlt}
+      pageType={pageType}
+      pubDate={pubDate}
+      author={author}
+      noindex={noindex}
+      breadcrumbs={breadcrumbs}
+      schemas={schemas}
+    />
 
     <script is:inline>
       (function() {
@@ -62,13 +73,6 @@ pubDate = pubDate ? new Date(pubDate).toLocaleDateString('fr-FR') : new Date().t
     <link rel="stylesheet" href="/styles/normalize.css">
     <link rel="stylesheet" href="/styles/reset.css">
     <link rel="stylesheet" href="/styles/theme.css">
-
-    <!-- Open Graph -->
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content={`https://nx.academy${pathname}`} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content={image} />
 
     <link
       rel="alternate"

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -10,7 +10,10 @@ type Heading = {
 interface Props {
   frontmatter: {
     title?: string;
+    description?: string;
     imgSrc?: string;
+    imgAlt?: string;
+    author?: string;
     publishedDate?: string;
   };
   headings: Heading[];
@@ -20,7 +23,7 @@ import BaseLayout from "./BaseLayout.astro";
 import StickyOutline from "../components/StickyOutline.astro";
 
 const {
-  frontmatter: { title, imgSrc, publishedDate },
+  frontmatter: { title, description, imgSrc, imgAlt, author, publishedDate },
   headings,
 } = Astro.props;
 
@@ -38,8 +41,12 @@ const breadCrumbs: Breadcrumb[] = [
 
 <BaseLayout
   title={title}
+  description={description}
   image={imgSrc}
+  imageAlt={imgAlt}
+  author={author}
   pubDate={publishedDate}
+  pageType="article"
   breadcrumbs={title === "Le manifeste" || title === "Changelog"
     ? []
     : breadCrumbs}

--- a/src/layouts/ChapterLayout.astro
+++ b/src/layouts/ChapterLayout.astro
@@ -33,7 +33,12 @@ const previousFullChapterLink = `${baseUrl}/chapitres/${previousChapterLink}`;
 const nextFullChapterLink = `${baseUrl}/chapitres/${nextChapterLink}`;
 ---
 
-<BaseLayout title={title} description={description} breadcrumbs={breadcrumbs}>
+<BaseLayout
+  title={title}
+  description={description}
+  pageType="article"
+  breadcrumbs={breadcrumbs}
+>
   <div class="main-wrapper">
     <section>
       <slot />

--- a/src/layouts/CheatSheetsLayout.astro
+++ b/src/layouts/CheatSheetsLayout.astro
@@ -12,6 +12,9 @@ interface Props {
     title: string;
     description: string;
     imgSrc?: string;
+    imgAlt?: string;
+    author?: string;
+    publishedDate?: string;
   };
   headings: Heading[];
 }
@@ -20,7 +23,7 @@ import BaseLayout from "./BaseLayout.astro";
 import StickyOutline from "../components/StickyOutline.astro";
 
 const {
-  frontmatter: { title, description, imgSrc },
+  frontmatter: { title, description, imgSrc, imgAlt, author, publishedDate },
   headings,
 } = Astro.props;
 
@@ -40,6 +43,10 @@ const breadCrumbs: Breadcrumb[] = [
   breadcrumbs={breadCrumbs}
   description={description}
   image={imgSrc}
+  imageAlt={imgAlt}
+  author={author}
+  pubDate={publishedDate}
+  pageType="article"
   title={title}
 >
   <main>

--- a/src/layouts/CourseLandingLayout.astro
+++ b/src/layouts/CourseLandingLayout.astro
@@ -66,12 +66,40 @@ for (const chapter of sortedChapters) {
   }
   sections.get(sectionNumber)?.push(chapter);
 }
+
+const SITE_URL = "https://nx.academy";
+
+const courseSchema = {
+  "@type": "Course",
+  name: courseTitle,
+  description: courseDescription,
+  url: `${SITE_URL}${courseUrl}`,
+  image: `${SITE_URL}${srcPicture}`,
+  inLanguage: "fr-FR",
+  educationalLevel: courseLevel,
+  teaches: courseGoals,
+  provider: { "@id": `${SITE_URL}/#organization` },
+  offers: {
+    "@type": "Offer",
+    category: "Free",
+    price: 0,
+    priceCurrency: "EUR",
+  },
+  hasCourseInstance: {
+    "@type": "CourseInstance",
+    courseMode: "online",
+    courseWorkload: `PT${courseDuration}H`,
+  },
+};
 ---
 
 <BaseLayout
   title={courseTitle}
   description={courseDescription}
+  image={srcPicture}
+  imageAlt={altPicture}
   breadcrumbs={breadCrumbs}
+  schemas={[courseSchema]}
 >
   <main class="main-wrapper">
     <section class="main-section">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,7 +7,7 @@ const pageTitle = "Page non trouvée";
 const pageDescription = "";
 ---
 
-<BaseLayout title={pageTitle}>
+<BaseLayout title={pageTitle} noindex={true}>
   <main class="main-wrapper">
     <div class="content-wrapper">
       <h1>Page introuvable</h1>

--- a/src/pages/quiz/index.astro
+++ b/src/pages/quiz/index.astro
@@ -5,9 +5,13 @@ import QuizCard from "../../components/QuizCard.astro";
 import Warning from "../../components/Warning.astro";
 
 import { QUIZZES } from "../../data/quiz";
+
+const pageTitle = "Nos quiz";
+const pageDescription =
+  "Testez vos connaissances en programmation et en devops avec les quiz gratuits de NX Academy. Évaluez votre niveau, sans inscription.";
 ---
 
-<BaseLayout>
+<BaseLayout title={pageTitle} description={pageDescription}>
   <main>
     <h1>Nos derniers quiz</h1>
     <Warning />


### PR DESCRIPTION
## Description

This PR extracts SEO metadata handling into a dedicated `Seo.astro` component and enhances SEO capabilities across the site.

### Key Changes

- **New `Seo.astro` component**: Centralized management of all SEO-related meta tags, Open Graph, Twitter Cards, and JSON-LD structured data
- **Enhanced structured data**: Added support for:
  - Organization schema
  - WebSite schema (homepage only)
  - BreadcrumbList schema
  - BlogPosting schema for articles
  - Course schema for course landing pages
  - Custom schema injection via `schemas` prop
- **Improved BaseLayout**: Simplified by delegating SEO concerns to the new component; added support for `imageAlt`, `pageType`, `author`, `noindex`, and `schemas` props
- **Updated child layouts**: 
  - `BlogPostLayout`: Now passes article metadata (`description`, `imgAlt`, `author`, `pageType`)
  - `CheatSheetsLayout`: Added article metadata support
  - `ChapterLayout`: Added `pageType="article"`
  - `CourseLandingLayout`: Added Course schema generation with educational metadata
- **Sitemap improvements**: Fixed filter logic and added dynamic priority rules (homepage: 1.0, courses: 0.9, legal pages: 0.3)
- **Minor fixes**: Updated HTML lang attribute to `fr` and viewport meta tag

### Benefits

- Better SEO with comprehensive structured data support
- Cleaner, more maintainable code with separation of concerns
- Easier to add SEO metadata to new pages
- Improved Open Graph and Twitter Card support
- Support for article-specific and course-specific metadata

## Things to check before merging:

- [ ] Did you update the changelog?
- [ ] Did you link GH issues using the Closes directive?

https://claude.ai/code/session_011qQXztFc24ZcDYjJWQ6TKE