### PR TITLE
Redesign article layout with editorial header and reading enhancements

### DIFF
--- a/public/styles/reset.css
+++ b/public/styles/reset.css
@@ -17,6 +17,10 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+a {
+  text-decoration: none;
+}
+
 img,
 picture,
 video,

--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,3 +1,26 @@
+/* Tokens partagés, constants quel que soit le thème (rayons, layout, motion,
+   polices). Les couleurs restent pilotées par thème ci-dessous. */
+:root {
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-pill: 999px;
+
+  --container-max: 1100px;
+  --container-width: 90%;
+
+  --transition: 0.4s ease;
+  --transition-fast: 0.3s ease;
+
+  --font-display: "Pixelify Sans", sans-serif;
+  --font-heading: "Space Grotesk", sans-serif;
+  --font-body: "Inter Variable", sans-serif;
+  --font-mono: ui-monospace, Menlo, Consolas, "Liberation Mono", monospace;
+
+  --fs-brand: 1.4rem;
+  --fs-xs: 0.72rem;
+}
+
 /* By default, NX is in dark mode */
 :root {
   --backgroundColorPrimary: #151515;

--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -1,0 +1,94 @@
+---
+import Button from "./Button.astro";
+
+interface Props {
+  author?: string;
+}
+
+const { author = "Thomas" } = Astro.props;
+---
+
+<aside class="art-author">
+  <img class="aa-avatar" src="/logo-mark.png" alt="" />
+  <div class="aa-body">
+    <p class="aa-eyebrow">L'auteur</p>
+    <h4>{author}</h4>
+    <p class="aa-bio">
+      Créateur de NX Academy. J'écris sur le développement, le jeu vidéo et les
+      outils qui me passionnent — entre carnets de bord et fiches pratiques.
+    </p>
+    <div class="aa-links">
+      <span class="aa-btn">
+        <Button
+          label="Suivre sur GitHub"
+          type="primary"
+          href="https://github.com/nx-academy"
+          external
+        />
+      </span>
+      <span class="aa-btn">
+        <Button label="Voir tous les articles" type="ghost" href="/articles" />
+      </span>
+    </div>
+  </div>
+</aside>
+
+<style>
+  .art-author {
+    display: flex;
+    gap: 1.3rem;
+    align-items: flex-start;
+    background: var(--backgroundColorSecondary);
+    border: 1px solid var(--borderPrimary);
+    border-radius: var(--radius-lg);
+    padding: 1.6rem 1.8rem;
+    margin-top: 2.8rem;
+  }
+  .aa-avatar {
+    width: 64px;
+    height: 64px;
+    flex: 0 0 auto;
+    image-rendering: pixelated;
+    border-radius: 12px;
+    background: var(--backgroundColorPrimary);
+    padding: 6px;
+    border: 1px solid var(--borderPrimary);
+    margin: 0;
+  }
+  .aa-body {
+    flex: 1;
+  }
+  .aa-eyebrow {
+    color: var(--accent);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    margin: 0 0 0.3rem;
+  }
+  .aa-body h4 {
+    font-family: var(--font-heading);
+    color: var(--titleColor);
+    font-size: 1.3rem;
+    margin: 0 0 0.5rem;
+  }
+  .aa-bio {
+    margin: 0 0 1rem;
+    color: var(--textColor);
+    line-height: 1.6;
+    font-size: 0.96rem;
+  }
+  .aa-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+  }
+  /* Le composant Button occupe 100 % ; on borne sa largeur dans la carte. */
+  .aa-btn {
+    display: inline-flex;
+  }
+  .aa-btn :global(a) {
+    width: auto;
+    font-size: 0.92rem;
+  }
+</style>

--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -3,9 +3,15 @@ import Button from "./Button.astro";
 
 interface Props {
   author?: string;
+  ctaHref?: string;
+  ctaLabel?: string;
 }
 
-const { author = "Thomas" } = Astro.props;
+const {
+  author = "Thomas",
+  ctaHref = "/articles",
+  ctaLabel = "Voir tous les articles",
+} = Astro.props;
 ---
 
 <aside class="art-author">
@@ -27,7 +33,7 @@ const { author = "Thomas" } = Astro.props;
         />
       </span>
       <span class="aa-btn">
-        <Button label="Voir tous les articles" type="ghost" href="/articles" />
+        <Button label={ctaLabel} type="ghost" href={ctaHref} />
       </span>
     </div>
   </div>

--- a/src/components/EditorialHeader.astro
+++ b/src/components/EditorialHeader.astro
@@ -1,0 +1,179 @@
+---
+// En-tête éditorial partagé (articles + fiches techniques) : kicker, titre,
+// chapô, byline avec pastille de temps de lecture, rangée de chips, image hero.
+// Les données viennent du frontmatter, transmises par le layout.
+interface Props {
+  kicker?: string;
+  title?: string;
+  description?: string;
+  author?: string;
+  formattedDate?: string;
+  chips?: string[];
+  imgSrc?: string;
+  imgAlt?: string;
+}
+
+const {
+  kicker,
+  title,
+  description,
+  author,
+  formattedDate,
+  chips,
+  imgSrc,
+  imgAlt,
+} = Astro.props;
+---
+
+<header class="article-head">
+  {kicker && <p class="kicker">{kicker}</p>}
+  <h1 class="article-title">{title}</h1>
+  {description && <p class="lead">{description}</p>}
+  <div class="byline">
+    <img class="byline-avatar" src="/logo-mark.png" alt="" />
+    <span class="byline-who">Par {author}</span>
+    <span class="byline-dot" aria-hidden="true"></span>
+    <span class="byline-date">le {formattedDate}</span>
+    <span class="reading-pill">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.8"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="9"></circle>
+        <path d="M12 7v5l3 2"></path>
+      </svg>
+      <b data-reading-min>—</b> de lecture
+    </span>
+  </div>
+  {
+    chips && chips.length > 0 && (
+      <div class="tags">
+        {chips.map((chip) => (
+          <span class="chip">{chip}</span>
+        ))}
+      </div>
+    )
+  }
+  {imgSrc && <img class="hero" src={imgSrc} alt={imgAlt} />}
+</header>
+
+<style>
+  .article-head {
+    margin-bottom: 0.4rem;
+  }
+  .kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--accent);
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin: 0 0 1rem;
+  }
+  .kicker::before {
+    content: "";
+    width: 22px;
+    height: 2px;
+    background: var(--accent);
+  }
+  .article-title {
+    font-family: var(--font-heading);
+    color: var(--titleColor);
+    font-weight: 700;
+    font-size: clamp(2.1rem, 1.5rem + 2vw, 3rem);
+    line-height: 1.1;
+    margin: 0 0 1.1rem;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
+  }
+  .lead {
+    font-size: 1.2rem;
+    line-height: 1.55;
+    color: var(--textColor);
+    margin: 0 0 1.3rem;
+    max-width: 44ch;
+  }
+  .byline {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin: 0 0 1.2rem;
+  }
+  .byline-avatar {
+    width: 34px;
+    height: 34px;
+    border-radius: var(--radius-pill);
+    image-rendering: pixelated;
+    background: var(--backgroundColorSecondary);
+    border: 1px solid var(--borderPrimary);
+    padding: 3px;
+    margin: 0;
+  }
+  .byline-who {
+    color: var(--titleColor);
+    font-weight: 500;
+    font-size: 0.95rem;
+  }
+  .byline-dot {
+    width: 3px;
+    height: 3px;
+    border-radius: var(--radius-pill);
+    background: var(--textColor);
+    opacity: 0.6;
+  }
+  .byline-date {
+    color: var(--textColor);
+    font-size: 0.88rem;
+  }
+  .reading-pill {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    border: 1px solid var(--borderPrimary);
+    border-radius: var(--radius-pill);
+    padding: 5px 12px;
+    color: var(--textColor);
+    font-size: 0.82rem;
+  }
+  .reading-pill svg {
+    width: 14px;
+    height: 14px;
+  }
+  .reading-pill b {
+    color: var(--titleColor);
+    font-weight: 600;
+  }
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+    margin: 0 0 1.8rem;
+  }
+  .chip {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--buttonColorPrimary);
+    border: 1px solid var(--borderSecondary, var(--borderPrimary));
+    border-radius: var(--radius-sm);
+    padding: 3px 8px;
+  }
+  .hero {
+    aspect-ratio: 1792 / 1024;
+    width: 100%;
+    object-fit: cover;
+    object-position: top;
+    border-radius: var(--radius-lg);
+    margin: 0 0 2.4rem;
+  }
+</style>

--- a/src/components/Faq.astro
+++ b/src/components/Faq.astro
@@ -1,5 +1,5 @@
 ---
-// Affiche une section "Questions fréquentes" visible sur la page.
+// Affiche une section "Questions fréquentes" en accordéon (<details>/<summary>).
 // Le contenu provient du frontmatter (champ `faq`) et alimente aussi le
 // JSON-LD FAQPage : on garde ainsi une source unique, et le schema reste
 // conforme aux regles de Google (le contenu balise doit etre visible).
@@ -12,24 +12,73 @@ const { items } = Astro.props;
 
 {
   items && items.length > 0 && (
-    <section class="faq">
+    <section class="art-faq">
       <h2>Questions fréquentes</h2>
       {items.map((item) => (
-        <div class="faq-item">
-          <h3>{item.question}</h3>
+        <details class="faq-item">
+          <summary>
+            <span>{item.question}</span>
+            <span class="faq-chev" aria-hidden="true" />
+          </summary>
           <p>{item.answer}</p>
-        </div>
+        </details>
       ))}
     </section>
   )
 }
 
 <style>
-  .faq {
-    margin-top: 2.5rem;
+  .art-faq {
+    margin-top: 2.8rem;
+    border-top: 1px solid var(--borderPrimary);
+    padding-top: 1.8rem;
   }
-
+  .art-faq h2 {
+    font-family: var(--font-heading);
+    color: var(--titleColor);
+    font-size: 1.5rem;
+    margin: 0 0 1.2rem;
+  }
   .faq-item {
-    margin-bottom: 1.5rem;
+    border-bottom: 1px solid var(--borderPrimary);
+  }
+  .faq-item summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 1rem 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    font-family: var(--font-heading);
+    font-weight: 500;
+    color: var(--titleColor);
+    font-size: 1.05rem;
+    transition: color var(--transition);
+  }
+  .faq-item summary::-webkit-details-marker {
+    display: none;
+  }
+  .faq-item summary:hover {
+    color: var(--linkHoverColor);
+  }
+  .faq-chev {
+    width: 11px;
+    height: 11px;
+    flex: 0 0 auto;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
+    transition: transform var(--transition);
+    margin-right: 4px;
+  }
+  .faq-item[open] .faq-chev {
+    transform: rotate(-135deg);
+  }
+  .faq-item p {
+    margin: 0 0 1.1rem;
+    color: var(--textColor);
+    line-height: 1.65;
+    font-size: 1rem;
   }
 </style>

--- a/src/components/RelatedArticles.astro
+++ b/src/components/RelatedArticles.astro
@@ -1,0 +1,122 @@
+---
+import type { Article } from "../types/Article";
+
+interface Props {
+  currentUrl: string;
+  limit?: number;
+}
+
+const { currentUrl, limit = 3 } = Astro.props;
+
+const normalize = (path: string) => path.replace(/\/+$/, "");
+const current = normalize(currentUrl);
+
+// Sélection automatique : les derniers articles publiés, hors draft et hors
+// article courant. (À terme : recommandation par pertinence.)
+const articles = Object.values(
+  import.meta.glob("../pages/articles/*.md", { eager: true }),
+) as Article[];
+
+const related = articles
+  .filter(
+    (article) =>
+      !article.frontmatter.draft &&
+      article.url &&
+      normalize(article.url) !== current,
+  )
+  .sort(
+    (a, b) =>
+      new Date(b.frontmatter.publishedDate).getTime() -
+      new Date(a.frontmatter.publishedDate).getTime(),
+  )
+  .slice(0, limit);
+---
+
+{
+  related.length > 0 && (
+    <section class="art-related">
+      <h2 class="rl-head">À lire ensuite</h2>
+      <div class="rl-grid">
+        {related.map((article) => (
+          <a class="rl-card" href={article.url}>
+            <img
+              loading="lazy"
+              src={article.frontmatter.imgSrc}
+              alt={article.frontmatter.imgAlt}
+            />
+            <p class="rl-kind">Articles</p>
+            <h4>{article.frontmatter.title}</h4>
+            <p class="rl-meta">
+              Par {article.frontmatter.author} —{" "}
+              {new Date(article.frontmatter.publishedDate).toLocaleDateString(
+                "fr-FR",
+              )}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+<style>
+  .art-related {
+    margin-top: 2.8rem;
+  }
+  .rl-head {
+    font-family: var(--font-heading);
+    color: var(--titleColor);
+    font-size: 1.4rem;
+    margin: 0 0 1.3rem;
+  }
+  .rl-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.4rem;
+
+    @media screen and (min-width: 640px) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+  .rl-card {
+    text-decoration: none;
+    display: grid;
+    gap: 0.45rem;
+    align-content: start;
+    color: var(--linkColor);
+  }
+  .rl-card img {
+    aspect-ratio: 1792 / 1024;
+    object-fit: cover;
+    object-position: top;
+    border-radius: var(--radius-lg);
+    width: 100%;
+    margin: 0;
+  }
+  .rl-kind {
+    color: var(--textColor);
+    font-size: 0.78rem;
+    margin: 0.3rem 0 0;
+  }
+  .rl-card h4 {
+    font-family: var(--font-heading);
+    color: var(--linkColor);
+    font-size: 1.05rem;
+    font-weight: 600;
+    line-height: 1.25;
+    margin: 0;
+    transition: color var(--transition);
+  }
+  .rl-card:hover h4 {
+    color: var(--linkHoverColor);
+  }
+  .rl-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    color: var(--textColor);
+    font-size: 0.72rem;
+    margin: 0;
+  }
+</style>

--- a/src/components/RelatedContent.astro
+++ b/src/components/RelatedContent.astro
@@ -1,28 +1,49 @@
 ---
 import type { Article } from "../types/Article";
+import type { Cheatsheet } from "../types/Cheatsheet";
+
+type Item = {
+  frontmatter: {
+    draft?: boolean;
+    title: string;
+    imgSrc: string;
+    imgAlt: string;
+    author: string;
+    publishedDate: string;
+    level?: string;
+  };
+  url?: string;
+};
 
 interface Props {
   currentUrl: string;
+  source?: "articles" | "fiches";
   limit?: number;
 }
 
-const { currentUrl, limit = 3 } = Astro.props;
+const { currentUrl, source = "articles", limit = 3 } = Astro.props;
 
 const normalize = (path: string) => path.replace(/\/+$/, "");
 const current = normalize(currentUrl);
 
-// Sélection automatique : les derniers articles publiés, hors draft et hors
-// article courant. (À terme : recommandation par pertinence.)
-const articles = Object.values(
-  import.meta.glob("../pages/articles/*.md", { eager: true }),
-) as Article[];
+// `import.meta.glob` exige un chemin littéral statique : on glob les deux
+// dossiers et on choisit la source ensuite. (À terme : recommandation par
+// pertinence.)
+const articlesGlob = import.meta.glob("../pages/articles/*.md", {
+  eager: true,
+});
+const fichesGlob = import.meta.glob("../pages/fiches/*.md", { eager: true });
 
-const related = articles
+const isFiches = source === "fiches";
+const items = Object.values(
+  isFiches ? fichesGlob : articlesGlob,
+) as (Item & (Article | Cheatsheet))[];
+const kindLabel = isFiches ? "Fiche technique" : "Articles";
+
+const related = items
   .filter(
-    (article) =>
-      !article.frontmatter.draft &&
-      article.url &&
-      normalize(article.url) !== current,
+    (item) =>
+      !item.frontmatter.draft && item.url && normalize(item.url) !== current,
   )
   .sort(
     (a, b) =>
@@ -37,18 +58,24 @@ const related = articles
     <section class="art-related">
       <h2 class="rl-head">À lire ensuite</h2>
       <div class="rl-grid">
-        {related.map((article) => (
-          <a class="rl-card" href={article.url}>
+        {related.map((item) => (
+          <a class="rl-card" href={item.url}>
             <img
               loading="lazy"
-              src={article.frontmatter.imgSrc}
-              alt={article.frontmatter.imgAlt}
+              src={item.frontmatter.imgSrc}
+              alt={item.frontmatter.imgAlt}
             />
-            <p class="rl-kind">Articles</p>
-            <h4>{article.frontmatter.title}</h4>
+            <p class="rl-kind">{kindLabel}</p>
+            <h4>{item.frontmatter.title}</h4>
             <p class="rl-meta">
-              Par {article.frontmatter.author} —{" "}
-              {new Date(article.frontmatter.publishedDate).toLocaleDateString(
+              {isFiches && item.frontmatter.level && (
+                <>
+                  <span class="rl-lvl">{item.frontmatter.level}</span>
+                  <span class="rl-dot" aria-hidden="true" />
+                </>
+              )}
+              Par {item.frontmatter.author} —{" "}
+              {new Date(item.frontmatter.publishedDate).toLocaleDateString(
                 "fr-FR",
               )}
             </p>
@@ -118,5 +145,15 @@ const related = articles
     color: var(--textColor);
     font-size: 0.72rem;
     margin: 0;
+  }
+  .rl-lvl {
+    color: var(--titleColor);
+  }
+  .rl-dot {
+    width: 3px;
+    height: 3px;
+    border-radius: var(--radius-pill);
+    background: var(--textColor);
+    opacity: 0.6;
   }
 </style>

--- a/src/components/RelatedContent.astro
+++ b/src/components/RelatedContent.astro
@@ -35,9 +35,8 @@ const articlesGlob = import.meta.glob("../pages/articles/*.md", {
 const fichesGlob = import.meta.glob("../pages/fiches/*.md", { eager: true });
 
 const isFiches = source === "fiches";
-const items = Object.values(
-  isFiches ? fichesGlob : articlesGlob,
-) as (Item & (Article | Cheatsheet))[];
+const items = Object.values(isFiches ? fichesGlob : articlesGlob) as (Item &
+  (Article | Cheatsheet))[];
 const kindLabel = isFiches ? "Fiche technique" : "Articles";
 
 const related = items

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -1,0 +1,121 @@
+---
+interface Props {
+  title?: string;
+}
+
+const { title = "" } = Astro.props;
+---
+
+<section class="art-share" data-share-title={title}>
+  <span class="sh-label">Partager</span>
+
+  <a
+    class="sh-btn"
+    data-share="linkedin"
+    href="#"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Partager sur LinkedIn"
+  >
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path
+        d="M18.72 4H5.37A1.37 1.37 0 0 0 4 5.25v13.38A1.37 1.37 0 0 0 5.37 20h13.35A1.3 1.3 0 0 0 20 18.63V5.25A1.31 1.31 0 0 0 18.72 4ZM9 17.34H6.67v-7.13H9ZM7.89 9.13A1.35 1.35 0 1 1 9.13 7.9a1.29 1.29 0 0 1-1.24 1.23Zm9.45 8.21H15v-3.9c0-.93-.33-1.57-1.16-1.57a1.25 1.25 0 0 0-1.17.84 1.6 1.6 0 0 0-.08.56v4.07h-2.3v-7.13h2.3v1a2.3 2.3 0 0 1 2.1-1.15c1.51 0 2.65 1 2.65 3.13Z"
+      ></path>
+    </svg>
+  </a>
+
+  <button
+    class="sh-btn"
+    type="button"
+    data-share="copy"
+    aria-label="Copier le lien de l'article"
+  >
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+      ></path>
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+      ></path>
+    </svg>
+  </button>
+</section>
+
+<style>
+  .art-share {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 2.4rem;
+  }
+  .sh-label {
+    font-size: 0.85rem;
+    color: var(--textColor);
+    margin-right: 0.3rem;
+  }
+  .sh-btn {
+    width: 38px;
+    height: 38px;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--borderPrimary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--linkColor);
+    background: transparent;
+    cursor: pointer;
+    transition:
+      color var(--transition),
+      border-color var(--transition);
+  }
+  .sh-btn svg {
+    width: 17px;
+    height: 17px;
+  }
+  .sh-btn:hover,
+  .sh-btn.copied {
+    color: var(--linkHoverColor);
+    border-color: var(--linkHoverColor);
+  }
+</style>
+
+<script>
+  const section = document.querySelector<HTMLElement>(".art-share");
+  if (section) {
+    const url = window.location.href;
+    const title = section.getAttribute("data-share-title") ?? "";
+
+    const linkedin = section.querySelector<HTMLAnchorElement>(
+      '[data-share="linkedin"]',
+    );
+    if (linkedin) {
+      linkedin.href = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
+    }
+
+    const copyBtn = section.querySelector<HTMLButtonElement>(
+      '[data-share="copy"]',
+    );
+    if (copyBtn) {
+      copyBtn.addEventListener("click", () => {
+        if (!navigator.clipboard) return;
+        navigator.clipboard.writeText(url).then(() => {
+          copyBtn.classList.add("copied");
+          copyBtn.setAttribute("aria-label", "Lien copié ✓");
+          setTimeout(() => {
+            copyBtn.classList.remove("copied");
+            copyBtn.setAttribute("aria-label", "Copier le lien de l'article");
+          }, 1600);
+        });
+      });
+    }
+
+    // `title` est réservé pour de futurs réseaux (X, Bluesky…).
+    void title;
+  }
+</script>

--- a/src/components/StickyOutline.astro
+++ b/src/components/StickyOutline.astro
@@ -157,7 +157,11 @@ const NSEG = 12;
 
   // Offset de défilement sous le header sticky selon le type de page.
   const scrollOffset =
-    $pageType === "cours" ? 500 : $pageType === "article" ? 88 : 0;
+    $pageType === "cours"
+      ? 500
+      : $pageType === "article" || $pageType === "fiche"
+        ? 88
+        : 0;
 
   function scrollToTitle() {
     $sectionLinks.forEach((link) => {

--- a/src/components/StickyOutline.astro
+++ b/src/components/StickyOutline.astro
@@ -20,7 +20,11 @@ const sectionsHeading = headings.filter((heading) => heading.depth === 2);
 const NSEG = 12;
 ---
 
-<div class="wrapper" data-page={pageType} class:list={[{ numbered, "with-progress": progress }]}>
+<div
+  class="wrapper"
+  data-page={pageType}
+  class:list={[{ numbered, "with-progress": progress }]}
+>
   <Heading3 content="Contenu" />
   <ul class="sections-heading">
     {
@@ -135,7 +139,11 @@ const NSEG = 12;
     flex: 1;
     height: 10px;
     border-radius: 2px;
-    background: color-mix(in srgb, var(--backgroundColorPrimary) 70%, transparent);
+    background: color-mix(
+      in srgb,
+      var(--backgroundColorPrimary) 70%,
+      transparent
+    );
     border: 1px solid var(--borderPrimary);
     transition:
       background var(--transition),
@@ -144,7 +152,8 @@ const NSEG = 12;
   .outline-seg.on {
     background: var(--buttonColorPrimary);
     border-color: var(--buttonColorPrimary);
-    box-shadow: 0 0 8px color-mix(in srgb, var(--buttonColorPrimary) 50%, transparent);
+    box-shadow: 0 0 8px
+      color-mix(in srgb, var(--buttonColorPrimary) 50%, transparent);
   }
 </style>
 

--- a/src/components/StickyOutline.astro
+++ b/src/components/StickyOutline.astro
@@ -8,28 +8,50 @@ type Heading = {
 interface Props {
   headings: Heading[];
   pageType: string;
+  numbered?: boolean;
+  progress?: boolean;
 }
 
 import Heading3 from "./Heading3.astro";
 
-const { headings, pageType } = Astro.props;
+const { headings, pageType, numbered = false, progress = false } = Astro.props;
 
 const sectionsHeading = headings.filter((heading) => heading.depth === 2);
+const NSEG = 12;
 ---
 
-<div class="wrapper" data-page={pageType}>
+<div class="wrapper" data-page={pageType} class:list={[{ numbered, "with-progress": progress }]}>
   <Heading3 content="Contenu" />
   <ul class="sections-heading">
     {
-      sectionsHeading.map((heading) => (
+      sectionsHeading.map((heading, index) => (
         <li>
           <a class="section-link" href={`#${heading.slug}`}>
-            {heading.text}
+            {numbered && (
+              <span class="oi-num">{String(index + 1).padStart(2, "0")}</span>
+            )}
+            <span class="oi-label">{heading.text}</span>
           </a>
         </li>
       ))
     }
   </ul>
+
+  {
+    progress && (
+      <div class="outline-progress">
+        <div class="op-head">
+          <span>Progression</span>
+          <span class="outline-pct">0%</span>
+        </div>
+        <div class="outline-segs">
+          {Array.from({ length: NSEG }).map(() => (
+            <span class="outline-seg" />
+          ))}
+        </div>
+      </div>
+    )
+  }
 </div>
 
 <style>
@@ -56,6 +78,74 @@ const sectionsHeading = headings.filter((heading) => heading.depth === 2);
   .active {
     color: var(--linkHoverColor);
   }
+
+  /* --- Variante article : entrées numérotées + état actif à filet gauche --- */
+  .numbered .sections-heading li {
+    margin-bottom: 0;
+  }
+  .numbered .section-link {
+    display: flex;
+    gap: 10px;
+    align-items: baseline;
+    padding: 7px 0 7px 12px;
+    border-left: 2px solid transparent;
+    margin-left: -2px;
+    font-size: 0.9rem;
+    line-height: 1.35;
+    transition:
+      color var(--transition),
+      border-color var(--transition);
+  }
+  .numbered .section-link.active {
+    color: var(--linkHoverColor);
+    border-left-color: var(--buttonColorPrimary);
+  }
+  .numbered .oi-num {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    opacity: 0.6;
+    min-width: 18px;
+  }
+
+  /* --- Barre de progression à segments (reprise de la maquette V4) -------- */
+  .outline-progress {
+    margin-top: 18px;
+    padding-top: 16px;
+    border-top: 1px solid var(--borderPrimary);
+  }
+  .op-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--textColor);
+  }
+  .outline-pct {
+    color: var(--titleColor);
+  }
+  .outline-segs {
+    display: flex;
+    gap: 3px;
+  }
+  .outline-seg {
+    flex: 1;
+    height: 10px;
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--backgroundColorPrimary) 70%, transparent);
+    border: 1px solid var(--borderPrimary);
+    transition:
+      background var(--transition),
+      box-shadow var(--transition);
+  }
+  .outline-seg.on {
+    background: var(--buttonColorPrimary);
+    border-color: var(--buttonColorPrimary);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--buttonColorPrimary) 50%, transparent);
+  }
 </style>
 
 <script>
@@ -63,7 +153,11 @@ const sectionsHeading = headings.filter((heading) => heading.depth === 2);
   const $sectionLinks = document.querySelectorAll(".section-link");
   const $pageType = (
     document.querySelector(".wrapper") as HTMLDivElement
-  ).getAttribute("data-page");
+  )?.getAttribute("data-page");
+
+  // Offset de défilement sous le header sticky selon le type de page.
+  const scrollOffset =
+    $pageType === "cours" ? 500 : $pageType === "article" ? 88 : 0;
 
   function scrollToTitle() {
     $sectionLinks.forEach((link) => {
@@ -77,29 +171,28 @@ const sectionsHeading = headings.filter((heading) => heading.depth === 2);
         if (target) {
           const top = target.getBoundingClientRect().top + window.scrollY;
 
-          // cours contents have an image at the beginning of each section
-          const offset = $pageType === "cours" ? 500 : 0;
-
           window.scrollTo({
-            top: top - offset,
+            top: top - scrollOffset,
             behavior: "smooth",
           });
+
+          history.replaceState(null, "", href);
         }
       });
     });
   }
 
   function onScroll() {
-    let closestSection = null;
+    let closestSection: HTMLElement | null = null;
     let minDistance = Infinity;
 
     $sectionsTitle.forEach((section) => {
       const rect = section.getBoundingClientRect();
-      const distance = Math.abs(rect.top);
+      const distance = Math.abs(rect.top - 110);
 
-      if (rect.top <= window.innerHeight && distance < minDistance) {
+      if (rect.top - 200 <= 0 && distance < minDistance) {
         minDistance = distance;
-        closestSection = section;
+        closestSection = section as HTMLElement;
       }
     });
 
@@ -117,11 +210,10 @@ const sectionsHeading = headings.filter((heading) => heading.depth === 2);
     }
   }
 
-  window.addEventListener("scroll", function () {
-    onScroll();
-  });
-
+  window.addEventListener("scroll", onScroll, { passive: true });
+  window.addEventListener("resize", onScroll);
   window.addEventListener("DOMContentLoaded", function () {
     scrollToTitle();
+    onScroll();
   });
 </script>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -24,11 +24,14 @@ interface Props {
   headings: Heading[];
 }
 
+import "../styles/article-content.css";
+
 import BaseLayout from "./BaseLayout.astro";
 import StickyOutline from "../components/StickyOutline.astro";
+import EditorialHeader from "../components/EditorialHeader.astro";
 import Faq from "../components/Faq.astro";
 import AuthorCard from "../components/AuthorCard.astro";
-import RelatedArticles from "../components/RelatedArticles.astro";
+import RelatedContent from "../components/RelatedContent.astro";
 import ShareButtons from "../components/ShareButtons.astro";
 
 const {
@@ -117,42 +120,16 @@ const breadCrumbs: Breadcrumb[] = [
       <article class:list={[{ "article-col": isArticle }]}>
         {
           isArticle && (
-            <header class="article-head">
-              <p class="kicker">{kicker}</p>
-              <h1 class="article-title">{title}</h1>
-              {description && <p class="lead">{description}</p>}
-              <div class="byline">
-                <img class="byline-avatar" src="/logo-mark.png" alt="" />
-                <span class="byline-who">Par {author}</span>
-                <span class="byline-dot" aria-hidden="true" />
-                <span class="byline-date">le {formattedDate}</span>
-                <span class="reading-pill">
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    aria-hidden="true"
-                  >
-                    <circle cx="12" cy="12" r="9" />
-                    <path d="M12 7v5l3 2" />
-                  </svg>
-                  <b data-reading-min>—</b> de lecture
-                </span>
-              </div>
-              {tags && tags.length > 0 && (
-                <div class="tags">
-                  {tags.map((tag) => (
-                    <span class="chip">{tag}</span>
-                  ))}
-                </div>
-              )}
-              {imgSrc && (
-                <img class="hero" src={imgSrc} alt={imgAlt} />
-              )}
-            </header>
+            <EditorialHeader
+              kicker={kicker}
+              title={title}
+              description={description}
+              author={author}
+              formattedDate={formattedDate}
+              chips={tags}
+              imgSrc={imgSrc}
+              imgAlt={imgAlt}
+            />
           )
         }
 
@@ -170,7 +147,7 @@ const breadCrumbs: Breadcrumb[] = [
           isArticle && (
             <>
               <ShareButtons title={title} />
-              <p class="article-signoff author">Bonne lecture, {author}</p>
+              <p class="article-signoff">Bonne lecture, {author}</p>
             </>
           )
         }
@@ -179,7 +156,7 @@ const breadCrumbs: Breadcrumb[] = [
           isArticle && (
             <>
               <AuthorCard author={author} />
-              <RelatedArticles currentUrl={currentUrl} />
+              <RelatedContent currentUrl={currentUrl} source="articles" />
             </>
           )
         }
@@ -224,140 +201,6 @@ const breadCrumbs: Breadcrumb[] = [
     background-position: -2px -2px;
   }
 
-  /* --- Barre de progression fine (haut de page) --------------------------- */
-  .nx-progress-top {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    z-index: 200;
-    background: transparent;
-    pointer-events: none;
-  }
-  .nx-progress-top::after {
-    content: "";
-    display: block;
-    height: 100%;
-    width: 100%;
-    transform: scaleX(var(--p, 0));
-    transform-origin: 0 50%;
-    background: var(--buttonColorPrimary);
-    transition: transform 0.08s linear;
-  }
-
-  /* --- En-tête éditorial -------------------------------------------------- */
-  .article-head {
-    margin-bottom: 0.4rem;
-  }
-  .kicker {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    color: var(--accent);
-    font-size: 0.82rem;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    margin: 0 0 1rem;
-  }
-  .kicker::before {
-    content: "";
-    width: 22px;
-    height: 2px;
-    background: var(--accent);
-  }
-  .lead {
-    font-size: 1.2rem;
-    line-height: 1.55;
-    color: var(--textColor);
-    margin: 0 0 1.3rem;
-    max-width: 44ch;
-  }
-  .byline {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin: 0 0 1.2rem;
-  }
-  .byline-avatar {
-    width: 34px;
-    height: 34px;
-    border-radius: var(--radius-pill);
-    image-rendering: pixelated;
-    background: var(--backgroundColorSecondary);
-    border: 1px solid var(--borderPrimary);
-    padding: 3px;
-    margin: 0;
-  }
-  .byline-who {
-    color: var(--titleColor);
-    font-weight: 500;
-    font-size: 0.95rem;
-  }
-  .byline-dot {
-    width: 3px;
-    height: 3px;
-    border-radius: var(--radius-pill);
-    background: var(--textColor);
-    opacity: 0.6;
-  }
-  .byline-date {
-    color: var(--textColor);
-    font-size: 0.88rem;
-  }
-  .reading-pill {
-    margin-left: auto;
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    border: 1px solid var(--borderPrimary);
-    border-radius: var(--radius-pill);
-    padding: 5px 12px;
-    color: var(--textColor);
-    font-size: 0.82rem;
-  }
-  .reading-pill svg {
-    width: 14px;
-    height: 14px;
-  }
-  .reading-pill b {
-    color: var(--titleColor);
-    font-weight: 600;
-  }
-  .tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 7px;
-    margin: 0 0 1.8rem;
-  }
-  .chip {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--buttonColorPrimary);
-    border: 1px solid var(--borderSecondary, var(--borderPrimary));
-    border-radius: var(--radius-sm);
-    padding: 3px 8px;
-  }
-  .hero {
-    aspect-ratio: 1792 / 1024;
-    width: 100%;
-    object-fit: cover;
-    object-position: top;
-    border-radius: var(--radius-lg);
-    margin: 0 0 2.4rem;
-  }
-
-  .article-signoff {
-    font-family: var(--font-display);
-    font-size: 1.6rem;
-    color: var(--titleColor);
-    margin: 2rem 0 0;
-  }
-
   .aside-wrapper {
     display: none;
 
@@ -374,72 +217,55 @@ const breadCrumbs: Breadcrumb[] = [
 </style>
 
 <style is:global>
-  /* En-tête : le titre est rendu par le layout (.article-title). */
-  .article-title {
-    font-family: var(--font-heading);
-    color: var(--titleColor);
-    font-weight: 700;
-    font-size: clamp(2.1rem, 1.5rem + 2vw, 3rem);
-    line-height: 1.1;
-    margin: 0 0 1.1rem;
-    letter-spacing: -0.01em;
-    text-wrap: balance;
-  }
-
-  /* h1 des pages non-article (ex. manifeste) : style historique conservé. */
-  article:not(.prose) h1 {
+  /* Styles génériques pour les pages non-article rendues par ce layout
+     (ex. le manifeste, sans `kind`). Le contenu d'article est, lui, stylé via
+     `.prose` (article-content.css). */
+  article:not(.article-col) h1 {
     font-size: clamp(2.5rem, 0.75rem + 1.5vw, 4rem);
     margin-top: 0;
     margin-bottom: 1rem;
     color: var(--titleColor);
   }
 
-  h2 {
+  article:not(.article-col) h2 {
     font-size: 1.75rem;
     margin-bottom: 1rem;
     color: var(--titleColor);
   }
 
-  img {
+  article:not(.article-col) img {
     width: 100%;
     margin-bottom: 1rem;
     border-radius: 8px;
   }
 
-  hr {
-    color: var(--borderPrimary);
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  p {
+  article:not(.article-col) p {
     margin-bottom: 1.5rem;
     color: var(--textColor);
     font-size: clamp(0.875rem, 0.75rem + 1.5vw, 1.125rem);
   }
 
-  ul {
+  article:not(.article-col) ul {
     color: var(--textColor);
     margin-bottom: 2.5rem;
   }
 
-  li {
+  article:not(.article-col) li {
     color: var(--textColor);
     font-size: clamp(0.875rem, 0.75rem + 1.5vw, 1.125rem);
   }
 
-  a {
+  article:not(.article-col) a {
     text-decoration: none;
     color: var(--articleLinkColor);
     font-weight: 500;
     transition: 0.4s color;
-
-    &:hover {
-      color: var(--articleLinkHoverColor);
-    }
+  }
+  article:not(.article-col) a:hover {
+    color: var(--articleLinkHoverColor);
   }
 
-  blockquote {
+  article:not(.article-col) blockquote {
     margin-top: 2rem;
     margin-bottom: 2rem;
     padding-left: 2rem;
@@ -460,170 +286,6 @@ const breadCrumbs: Breadcrumb[] = [
     color: var(--textColor);
     margin-bottom: 2.5rem;
     display: block;
-  }
-
-  /* ======================================================================
-     Typographie de lecture des articles (.prose) — fidèle à la maquette V1+,
-     pilotée par les tokens du dépôt (compatible dark / light / summer).
-     ====================================================================== */
-  .prose h2 {
-    font-family: var(--font-heading);
-    color: var(--titleColor);
-    font-size: clamp(1.5rem, 1.2rem + 1vw, 1.9rem);
-    line-height: 1.2;
-    margin: 0 0 1.1rem;
-    scroll-margin-top: 88px;
-  }
-  .prose p {
-    font-size: clamp(1rem, 0.95rem + 0.25vw, 1.12rem);
-    line-height: 1.7;
-    margin: 0 0 1.35rem;
-    color: var(--textColor);
-    text-wrap: pretty;
-  }
-  .prose p strong,
-  .prose li strong {
-    color: var(--titleColor);
-    font-weight: 600;
-  }
-  .prose a {
-    color: var(--articleLinkColor);
-    text-decoration: none;
-    font-weight: 500;
-    border-bottom: 1px solid
-      color-mix(in srgb, var(--articleLinkColor) 35%, transparent);
-    transition:
-      color var(--transition),
-      border-color var(--transition);
-  }
-  .prose a:hover {
-    color: var(--articleLinkHoverColor);
-    border-color: var(--articleLinkHoverColor);
-  }
-  .prose ul {
-    margin: 0 0 1.6rem;
-    padding-left: 1.1rem;
-  }
-  .prose li {
-    font-size: clamp(1rem, 0.95rem + 0.25vw, 1.12rem);
-    line-height: 1.65;
-    margin-bottom: 0.6rem;
-    color: var(--textColor);
-  }
-  .prose li::marker {
-    color: var(--buttonColorPrimary);
-  }
-  .prose em {
-    font-style: italic;
-  }
-
-  /* Code en ligne — remplissage néon plein (signature NX) */
-  .prose :not(pre) > code {
-    font-family: var(--font-mono);
-    background: var(--codeBackgroundColor);
-    color: var(--codeTextColor);
-    padding: 0.1em 0.4em;
-    border-radius: var(--radius-sm);
-    font-size: 0.88em;
-  }
-  /* Bloc de code */
-  .prose pre {
-    position: relative;
-    background: color-mix(
-      in srgb,
-      var(--backgroundColorSecondary) 55%,
-      var(--backgroundColorPrimary)
-    );
-    border: 1px solid var(--borderPrimary);
-    border-radius: var(--radius-md);
-    padding: 18px 20px;
-    overflow: auto;
-    margin: 0 0 1.6rem;
-  }
-  .prose pre code {
-    font-family: var(--font-mono);
-    color: var(--titleColor);
-    font-size: 0.9rem;
-    line-height: 1.65;
-    background: none;
-    padding: 0;
-    white-space: pre;
-  }
-
-  /* Citation en exergue (reprise de la maquette V2) */
-  .prose blockquote {
-    position: relative;
-    border-left: none;
-    margin: 2.4rem 0;
-    padding: 0.5rem 0 0.5rem 3rem;
-    font-family: var(--font-heading);
-    font-size: 1.5rem;
-    line-height: 1.42;
-    color: var(--titleColor);
-    font-style: normal;
-  }
-  .prose blockquote::before {
-    content: "\201C";
-    position: absolute;
-    left: -2px;
-    top: -0.5rem;
-    font-family: var(--font-heading);
-    font-size: 4rem;
-    color: var(--accent);
-    line-height: 1;
-  }
-  .prose blockquote p {
-    margin: 0;
-    font-size: inherit;
-    line-height: inherit;
-    color: inherit;
-  }
-
-  /* Bouton « copier » injecté dans les blocs de code */
-  .nx-copy {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-family: var(--font-body);
-    font-size: 0.72rem;
-    letter-spacing: 0.02em;
-    cursor: pointer;
-    color: var(--textColor);
-    background: color-mix(
-      in srgb,
-      var(--backgroundColorPrimary) 80%,
-      transparent
-    );
-    border: 1px solid var(--borderPrimary);
-    border-radius: 6px;
-    padding: 4px 9px;
-    opacity: 0;
-    transition:
-      opacity var(--transition-fast),
-      color var(--transition-fast),
-      border-color var(--transition-fast);
-  }
-  .prose pre:hover .nx-copy,
-  .nx-copy:focus-visible {
-    opacity: 1;
-  }
-  .nx-copy:hover,
-  .nx-copy.copied {
-    color: var(--buttonColorPrimary);
-    border-color: var(--buttonColorPrimary);
-    opacity: 1;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    * {
-      scroll-behavior: auto !important;
-    }
-    .nx-progress-top::after {
-      transition: none;
-    }
   }
 </style>
 

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -168,7 +168,10 @@ const breadCrumbs: Breadcrumb[] = [
 
         {
           isArticle && (
-            <p class="article-signoff author">Bonne lecture. — {author}</p>
+            <>
+              <ShareButtons title={title} />
+              <p class="article-signoff author">Bonne lecture, {author}</p>
+            </>
           )
         }
         <Faq items={faq} />
@@ -177,7 +180,6 @@ const breadCrumbs: Breadcrumb[] = [
             <>
               <AuthorCard author={author} />
               <RelatedArticles currentUrl={currentUrl} />
-              <ShareButtons title={title} />
             </>
           )
         }
@@ -363,6 +365,10 @@ const breadCrumbs: Breadcrumb[] = [
       display: block;
       position: sticky;
       top: 88px;
+      background: var(--backgroundColorSecondary);
+      border: 1px solid var(--borderPrimary);
+      border-radius: var(--radius-md);
+      padding: 22px 22px 20px;
     }
   }
 </style>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -62,7 +62,10 @@ const currentUrl = Astro.url.pathname;
 const normalize = (path: string) => path.replace(/\/+$/, "");
 const allArticles = Object.values(
   import.meta.glob("../pages/articles/*.md", { eager: true }),
-) as { frontmatter: { draft?: boolean; publishedDate: string }; url?: string }[];
+) as {
+  frontmatter: { draft?: boolean; publishedDate: string };
+  url?: string;
+}[];
 const latest = allArticles
   .filter((article) => !article.frontmatter.draft && article.url)
   .sort(
@@ -113,7 +116,7 @@ const breadCrumbs: Breadcrumb[] = [
     : breadCrumbs}
   schemas={schemas}
 >
-  {isArticle && <div class="nx-progress-top" data-progress></div>}
+  {isArticle && <div class="nx-progress-top" data-progress />}
 
   <main class="main-wrapper" class:list={[{ "is-article": isArticle }]}>
     <section>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -54,6 +54,24 @@ const formattedDate = publishedDate
   : "";
 const currentUrl = Astro.url.pathname;
 
+// Le kicker « À la une » n'est affiché que sur le dernier article publié ;
+// les autres articles affichent seulement leur `kind` (ex. « Articles »).
+const normalize = (path: string) => path.replace(/\/+$/, "");
+const allArticles = Object.values(
+  import.meta.glob("../pages/articles/*.md", { eager: true }),
+) as { frontmatter: { draft?: boolean; publishedDate: string }; url?: string }[];
+const latest = allArticles
+  .filter((article) => !article.frontmatter.draft && article.url)
+  .sort(
+    (a, b) =>
+      new Date(b.frontmatter.publishedDate).getTime() -
+      new Date(a.frontmatter.publishedDate).getTime(),
+  )[0];
+const isLatest = Boolean(
+  latest && latest.url && normalize(latest.url) === normalize(currentUrl),
+);
+const kicker = isLatest ? `À la une · ${kind}` : kind;
+
 // JSON-LD FAQPage genere a partir du frontmatter (cf. composant Faq).
 const schemas: Record<string, unknown>[] = [];
 if (faq && faq.length > 0) {
@@ -96,11 +114,11 @@ const breadCrumbs: Breadcrumb[] = [
 
   <main class="main-wrapper" class:list={[{ "is-article": isArticle }]}>
     <section>
-      <article class:list={[{ prose: isArticle }]} data-prose={isArticle ? "" : null}>
+      <article class:list={[{ "article-col": isArticle }]}>
         {
           isArticle && (
             <header class="article-head">
-              <p class="kicker">À la une · {kind}</p>
+              <p class="kicker">{kicker}</p>
               <h1 class="article-title">{title}</h1>
               {description && <p class="lead">{description}</p>}
               <div class="byline">
@@ -138,7 +156,15 @@ const breadCrumbs: Breadcrumb[] = [
           )
         }
 
-        <slot />
+        {
+          isArticle ? (
+            <div class="prose" data-prose>
+              <slot />
+            </div>
+          ) : (
+            <slot />
+          )
+        }
 
         {
           isArticle && (
@@ -183,12 +209,11 @@ const breadCrumbs: Breadcrumb[] = [
       display: grid;
       grid-template-columns: minmax(0, 1fr) 320px;
       gap: 56px;
-      align-items: start;
     }
   }
 
   /* Fond papier pointillé (repris de la maquette V3) sur la colonne article */
-  main.is-article .prose {
+  main.is-article .article-col {
     background-image: radial-gradient(
       color-mix(in srgb, var(--borderPrimary) 65%, transparent) 1px,
       transparent 1px

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -15,8 +15,10 @@ interface Props {
     description?: string;
     imgSrc?: string;
     imgAlt?: string;
+    kind?: string;
     author?: string;
     publishedDate?: string;
+    tags?: string[];
     faq?: FaqItem[];
   };
   headings: Heading[];
@@ -25,6 +27,9 @@ interface Props {
 import BaseLayout from "./BaseLayout.astro";
 import StickyOutline from "../components/StickyOutline.astro";
 import Faq from "../components/Faq.astro";
+import AuthorCard from "../components/AuthorCard.astro";
+import RelatedArticles from "../components/RelatedArticles.astro";
+import ShareButtons from "../components/ShareButtons.astro";
 
 const {
   frontmatter: {
@@ -32,12 +37,22 @@ const {
     description,
     imgSrc,
     imgAlt,
+    kind,
     author,
     publishedDate,
+    tags,
     faq,
   },
   headings,
 } = Astro.props;
+
+// L'en-tête éditorial et les blocs de fin ne s'appliquent qu'aux vrais articles
+// (tous ont `kind`). Les pages sans `kind` (ex. le manifeste) gardent leur rendu.
+const isArticle = Boolean(kind);
+const formattedDate = publishedDate
+  ? new Date(publishedDate).toLocaleDateString("fr-FR")
+  : "";
+const currentUrl = Astro.url.pathname;
 
 // JSON-LD FAQPage genere a partir du frontmatter (cf. composant Faq).
 const schemas: Record<string, unknown>[] = [];
@@ -77,16 +92,79 @@ const breadCrumbs: Breadcrumb[] = [
     : breadCrumbs}
   schemas={schemas}
 >
-  <main class="main-wrapper">
+  {isArticle && <div class="nx-progress-top" data-progress></div>}
+
+  <main class="main-wrapper" class:list={[{ "is-article": isArticle }]}>
     <section>
-      <article>
+      <article class:list={[{ prose: isArticle }]} data-prose={isArticle ? "" : null}>
+        {
+          isArticle && (
+            <header class="article-head">
+              <p class="kicker">À la une · {kind}</p>
+              <h1 class="article-title">{title}</h1>
+              {description && <p class="lead">{description}</p>}
+              <div class="byline">
+                <img class="byline-avatar" src="/logo-mark.png" alt="" />
+                <span class="byline-who">Par {author}</span>
+                <span class="byline-dot" aria-hidden="true" />
+                <span class="byline-date">le {formattedDate}</span>
+                <span class="reading-pill">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                    <path d="M12 7v5l3 2" />
+                  </svg>
+                  <b data-reading-min>—</b> de lecture
+                </span>
+              </div>
+              {tags && tags.length > 0 && (
+                <div class="tags">
+                  {tags.map((tag) => (
+                    <span class="chip">{tag}</span>
+                  ))}
+                </div>
+              )}
+              {imgSrc && (
+                <img class="hero" src={imgSrc} alt={imgAlt} />
+              )}
+            </header>
+          )
+        }
+
         <slot />
+
+        {
+          isArticle && (
+            <p class="article-signoff author">Bonne lecture. — {author}</p>
+          )
+        }
         <Faq items={faq} />
+        {
+          isArticle && (
+            <>
+              <AuthorCard author={author} />
+              <RelatedArticles currentUrl={currentUrl} />
+              <ShareButtons title={title} />
+            </>
+          )
+        }
       </article>
     </section>
     <aside>
       <div class="aside-wrapper">
-        <StickyOutline headings={headings} pageType="fiche" />
+        <StickyOutline
+          headings={headings}
+          pageType="article"
+          numbered={isArticle}
+          progress={isArticle}
+        />
       </div>
     </aside>
   </main>
@@ -96,36 +174,189 @@ const breadCrumbs: Breadcrumb[] = [
   main {
     padding-top: 1.5rem;
     padding-bottom: 1.5rem;
-    width: 90%;
-    max-width: 1100px;
+    width: var(--container-width);
+    max-width: var(--container-max);
     margin-left: auto;
     margin-right: auto;
 
     @media screen and (min-width: 1024px) {
       display: grid;
-      grid-template-columns: 65% 35%;
-      gap: 64px;
+      grid-template-columns: minmax(0, 1fr) 320px;
+      gap: 56px;
+      align-items: start;
     }
+  }
+
+  /* Fond papier pointillé (repris de la maquette V3) sur la colonne article */
+  main.is-article .prose {
+    background-image: radial-gradient(
+      color-mix(in srgb, var(--borderPrimary) 65%, transparent) 1px,
+      transparent 1px
+    );
+    background-size: 24px 24px;
+    background-position: -2px -2px;
+  }
+
+  /* --- Barre de progression fine (haut de page) --------------------------- */
+  .nx-progress-top {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    z-index: 200;
+    background: transparent;
+    pointer-events: none;
+  }
+  .nx-progress-top::after {
+    content: "";
+    display: block;
+    height: 100%;
+    width: 100%;
+    transform: scaleX(var(--p, 0));
+    transform-origin: 0 50%;
+    background: var(--buttonColorPrimary);
+    transition: transform 0.08s linear;
+  }
+
+  /* --- En-tête éditorial -------------------------------------------------- */
+  .article-head {
+    margin-bottom: 0.4rem;
+  }
+  .kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--accent);
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin: 0 0 1rem;
+  }
+  .kicker::before {
+    content: "";
+    width: 22px;
+    height: 2px;
+    background: var(--accent);
+  }
+  .lead {
+    font-size: 1.2rem;
+    line-height: 1.55;
+    color: var(--textColor);
+    margin: 0 0 1.3rem;
+    max-width: 44ch;
+  }
+  .byline {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin: 0 0 1.2rem;
+  }
+  .byline-avatar {
+    width: 34px;
+    height: 34px;
+    border-radius: var(--radius-pill);
+    image-rendering: pixelated;
+    background: var(--backgroundColorSecondary);
+    border: 1px solid var(--borderPrimary);
+    padding: 3px;
+    margin: 0;
+  }
+  .byline-who {
+    color: var(--titleColor);
+    font-weight: 500;
+    font-size: 0.95rem;
+  }
+  .byline-dot {
+    width: 3px;
+    height: 3px;
+    border-radius: var(--radius-pill);
+    background: var(--textColor);
+    opacity: 0.6;
+  }
+  .byline-date {
+    color: var(--textColor);
+    font-size: 0.88rem;
+  }
+  .reading-pill {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    border: 1px solid var(--borderPrimary);
+    border-radius: var(--radius-pill);
+    padding: 5px 12px;
+    color: var(--textColor);
+    font-size: 0.82rem;
+  }
+  .reading-pill svg {
+    width: 14px;
+    height: 14px;
+  }
+  .reading-pill b {
+    color: var(--titleColor);
+    font-weight: 600;
+  }
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+    margin: 0 0 1.8rem;
+  }
+  .chip {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--buttonColorPrimary);
+    border: 1px solid var(--borderSecondary, var(--borderPrimary));
+    border-radius: var(--radius-sm);
+    padding: 3px 8px;
+  }
+  .hero {
+    aspect-ratio: 1792 / 1024;
+    width: 100%;
+    object-fit: cover;
+    object-position: top;
+    border-radius: var(--radius-lg);
+    margin: 0 0 2.4rem;
+  }
+
+  .article-signoff {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    color: var(--titleColor);
+    margin: 2rem 0 0;
   }
 
   .aside-wrapper {
     display: none;
 
     @media screen and (min-width: 1024px) {
-      background-color: var(--backgroundColorSecondary);
-      border-radius: 4px;
-      border: 1px solid var(--borderPrimary);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
       display: block;
-      padding: 24px;
       position: sticky;
-      top: 24px;
+      top: 88px;
     }
   }
 </style>
 
 <style is:global>
-  h1 {
+  /* En-tête : le titre est rendu par le layout (.article-title). */
+  .article-title {
+    font-family: var(--font-heading);
+    color: var(--titleColor);
+    font-weight: 700;
+    font-size: clamp(2.1rem, 1.5rem + 2vw, 3rem);
+    line-height: 1.1;
+    margin: 0 0 1.1rem;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
+  }
+
+  /* h1 des pages non-article (ex. manifeste) : style historique conservé. */
+  article:not(.prose) h1 {
     font-size: clamp(2.5rem, 0.75rem + 1.5vw, 4rem);
     margin-top: 0;
     margin-bottom: 1rem;
@@ -144,16 +375,26 @@ const breadCrumbs: Breadcrumb[] = [
     border-radius: 8px;
   }
 
+  hr {
+    color: var(--borderPrimary);
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
   p {
     margin-bottom: 1.5rem;
     color: var(--textColor);
     font-size: clamp(0.875rem, 0.75rem + 1.5vw, 1.125rem);
   }
 
-  hr {
-    color: var(--borderPrimary);
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
+  ul {
+    color: var(--textColor);
+    margin-bottom: 2.5rem;
+  }
+
+  li {
+    color: var(--textColor);
+    font-size: clamp(0.875rem, 0.75rem + 1.5vw, 1.125rem);
   }
 
   a {
@@ -165,16 +406,6 @@ const breadCrumbs: Breadcrumb[] = [
     &:hover {
       color: var(--articleLinkHoverColor);
     }
-  }
-
-  ul {
-    color: var(--textColor);
-    margin-bottom: 2.5rem;
-  }
-
-  li {
-    color: var(--textColor);
-    font-size: clamp(0.875rem, 0.75rem + 1.5vw, 1.125rem);
   }
 
   blockquote {
@@ -199,9 +430,176 @@ const breadCrumbs: Breadcrumb[] = [
     margin-bottom: 2.5rem;
     display: block;
   }
+
+  /* ======================================================================
+     Typographie de lecture des articles (.prose) — fidèle à la maquette V1+,
+     pilotée par les tokens du dépôt (compatible dark / light / summer).
+     ====================================================================== */
+  .prose h2 {
+    font-family: var(--font-heading);
+    color: var(--titleColor);
+    font-size: clamp(1.5rem, 1.2rem + 1vw, 1.9rem);
+    line-height: 1.2;
+    margin: 0 0 1.1rem;
+    scroll-margin-top: 88px;
+  }
+  .prose p {
+    font-size: clamp(1rem, 0.95rem + 0.25vw, 1.12rem);
+    line-height: 1.7;
+    margin: 0 0 1.35rem;
+    color: var(--textColor);
+    text-wrap: pretty;
+  }
+  .prose p strong,
+  .prose li strong {
+    color: var(--titleColor);
+    font-weight: 600;
+  }
+  .prose a {
+    color: var(--articleLinkColor);
+    text-decoration: none;
+    font-weight: 500;
+    border-bottom: 1px solid
+      color-mix(in srgb, var(--articleLinkColor) 35%, transparent);
+    transition:
+      color var(--transition),
+      border-color var(--transition);
+  }
+  .prose a:hover {
+    color: var(--articleLinkHoverColor);
+    border-color: var(--articleLinkHoverColor);
+  }
+  .prose ul {
+    margin: 0 0 1.6rem;
+    padding-left: 1.1rem;
+  }
+  .prose li {
+    font-size: clamp(1rem, 0.95rem + 0.25vw, 1.12rem);
+    line-height: 1.65;
+    margin-bottom: 0.6rem;
+    color: var(--textColor);
+  }
+  .prose li::marker {
+    color: var(--buttonColorPrimary);
+  }
+  .prose em {
+    font-style: italic;
+  }
+
+  /* Code en ligne — remplissage néon plein (signature NX) */
+  .prose :not(pre) > code {
+    font-family: var(--font-mono);
+    background: var(--codeBackgroundColor);
+    color: var(--codeTextColor);
+    padding: 0.1em 0.4em;
+    border-radius: var(--radius-sm);
+    font-size: 0.88em;
+  }
+  /* Bloc de code */
+  .prose pre {
+    position: relative;
+    background: color-mix(
+      in srgb,
+      var(--backgroundColorSecondary) 55%,
+      var(--backgroundColorPrimary)
+    );
+    border: 1px solid var(--borderPrimary);
+    border-radius: var(--radius-md);
+    padding: 18px 20px;
+    overflow: auto;
+    margin: 0 0 1.6rem;
+  }
+  .prose pre code {
+    font-family: var(--font-mono);
+    color: var(--titleColor);
+    font-size: 0.9rem;
+    line-height: 1.65;
+    background: none;
+    padding: 0;
+    white-space: pre;
+  }
+
+  /* Citation en exergue (reprise de la maquette V2) */
+  .prose blockquote {
+    position: relative;
+    border-left: none;
+    margin: 2.4rem 0;
+    padding: 0.5rem 0 0.5rem 3rem;
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    line-height: 1.42;
+    color: var(--titleColor);
+    font-style: normal;
+  }
+  .prose blockquote::before {
+    content: "\201C";
+    position: absolute;
+    left: -2px;
+    top: -0.5rem;
+    font-family: var(--font-heading);
+    font-size: 4rem;
+    color: var(--accent);
+    line-height: 1;
+  }
+  .prose blockquote p {
+    margin: 0;
+    font-size: inherit;
+    line-height: inherit;
+    color: inherit;
+  }
+
+  /* Bouton « copier » injecté dans les blocs de code */
+  .nx-copy {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-body);
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    color: var(--textColor);
+    background: color-mix(
+      in srgb,
+      var(--backgroundColorPrimary) 80%,
+      transparent
+    );
+    border: 1px solid var(--borderPrimary);
+    border-radius: 6px;
+    padding: 4px 9px;
+    opacity: 0;
+    transition:
+      opacity var(--transition-fast),
+      color var(--transition-fast),
+      border-color var(--transition-fast);
+  }
+  .prose pre:hover .nx-copy,
+  .nx-copy:focus-visible {
+    opacity: 1;
+  }
+  .nx-copy:hover,
+  .nx-copy.copied {
+    color: var(--buttonColorPrimary);
+    border-color: var(--buttonColorPrimary);
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    * {
+      scroll-behavior: auto !important;
+    }
+    .nx-progress-top::after {
+      transition: none;
+    }
+  }
 </style>
 
 <script>
   import handleReadingTime from "../utils/estimateReadingTime";
+  import initArticleEnhancements from "../utils/articleEnhancements";
+
   handleReadingTime();
+  initArticleEnhancements();
 </script>

--- a/src/layouts/CheatSheetsLayout.astro
+++ b/src/layouts/CheatSheetsLayout.astro
@@ -62,7 +62,10 @@ const currentUrl = Astro.url.pathname;
 const normalize = (path: string) => path.replace(/\/+$/, "");
 const allFiches = Object.values(
   import.meta.glob("../pages/fiches/*.md", { eager: true }),
-) as { frontmatter: { draft?: boolean; publishedDate: string }; url?: string }[];
+) as {
+  frontmatter: { draft?: boolean; publishedDate: string };
+  url?: string;
+}[];
 const latest = allFiches
   .filter((fiche) => !fiche.frontmatter.draft && fiche.url)
   .sort(

--- a/src/layouts/CheatSheetsLayout.astro
+++ b/src/layouts/CheatSheetsLayout.astro
@@ -16,7 +16,9 @@ interface Props {
     description: string;
     imgSrc?: string;
     imgAlt?: string;
+    kind?: string;
     author?: string;
+    level?: string;
     publishedDate?: string;
     faq?: FaqItem[];
     howTo?: HowToData;
@@ -24,9 +26,15 @@ interface Props {
   headings: Heading[];
 }
 
+import "../styles/article-content.css";
+
 import BaseLayout from "./BaseLayout.astro";
 import StickyOutline from "../components/StickyOutline.astro";
+import EditorialHeader from "../components/EditorialHeader.astro";
 import Faq from "../components/Faq.astro";
+import AuthorCard from "../components/AuthorCard.astro";
+import RelatedContent from "../components/RelatedContent.astro";
+import ShareButtons from "../components/ShareButtons.astro";
 
 const {
   frontmatter: {
@@ -34,13 +42,42 @@ const {
     description,
     imgSrc,
     imgAlt,
+    kind,
     author,
+    level,
     publishedDate,
     faq,
     howTo,
   },
   headings,
 } = Astro.props;
+
+const formattedDate = publishedDate
+  ? new Date(publishedDate).toLocaleDateString("fr-FR")
+  : "";
+const currentUrl = Astro.url.pathname;
+
+// Le kicker « À la une » n'est affiché que sur la dernière fiche publiée ;
+// les autres affichent seulement leur `kind` (« Fiche technique »).
+const normalize = (path: string) => path.replace(/\/+$/, "");
+const allFiches = Object.values(
+  import.meta.glob("../pages/fiches/*.md", { eager: true }),
+) as { frontmatter: { draft?: boolean; publishedDate: string }; url?: string }[];
+const latest = allFiches
+  .filter((fiche) => !fiche.frontmatter.draft && fiche.url)
+  .sort(
+    (a, b) =>
+      new Date(b.frontmatter.publishedDate).getTime() -
+      new Date(a.frontmatter.publishedDate).getTime(),
+  )[0];
+const isLatest = Boolean(
+  latest && latest.url && normalize(latest.url) === normalize(currentUrl),
+);
+const kindLabel = kind ?? "Fiche technique";
+const kicker = isLatest ? `À la une · ${kindLabel}` : kindLabel;
+
+// La chip de l'en-tête reprend le niveau de la fiche (les fiches n'ont pas de tags).
+const chips = level ? [level] : undefined;
 
 // JSON-LD genere a partir du frontmatter : HowTo (tutoriels pas a pas) et
 // FAQPage (cf. composant Faq, dont le contenu reste visible sur la page).
@@ -91,14 +128,45 @@ const breadCrumbs: Breadcrumb[] = [
   title={title}
   schemas={schemas}
 >
-  <main>
+  <div class="nx-progress-top" data-progress></div>
+
+  <main class="main-wrapper is-article">
     <section>
-      <slot />
-      <Faq items={faq} />
+      <article class="article-col">
+        <EditorialHeader
+          kicker={kicker}
+          title={title}
+          description={description}
+          author={author}
+          formattedDate={formattedDate}
+          chips={chips}
+          imgSrc={imgSrc}
+          imgAlt={imgAlt}
+        />
+
+        <div class="prose" data-prose>
+          <slot />
+        </div>
+
+        <ShareButtons title={title} />
+        <p class="article-signoff">Bonne lecture, {author}</p>
+        <Faq items={faq} />
+        <AuthorCard
+          author={author}
+          ctaHref="/fiches"
+          ctaLabel="Voir toutes les fiches"
+        />
+        <RelatedContent currentUrl={currentUrl} source="fiches" />
+      </article>
     </section>
     <aside>
       <div class="aside-wrapper">
-        <StickyOutline headings={headings} pageType="fiche" />
+        <StickyOutline
+          headings={headings}
+          pageType="fiche"
+          numbered={true}
+          progress={true}
+        />
       </div>
     </aside>
   </main>
@@ -108,138 +176,47 @@ const breadCrumbs: Breadcrumb[] = [
   main {
     padding-top: 1.5rem;
     padding-bottom: 1.5rem;
-    width: 90%;
-    max-width: 1100px;
+    width: var(--container-width);
+    max-width: var(--container-max);
     margin-left: auto;
     margin-right: auto;
 
     @media screen and (min-width: 1024px) {
       display: grid;
-      grid-template-columns: 65% 30%;
-      gap: 64px;
+      grid-template-columns: minmax(0, 1fr) 320px;
+      gap: 56px;
     }
+  }
+
+  /* Fond papier pointillé (repris de la maquette V3) sur la colonne article */
+  main.is-article .article-col {
+    background-image: radial-gradient(
+      color-mix(in srgb, var(--borderPrimary) 65%, transparent) 1px,
+      transparent 1px
+    );
+    background-size: 24px 24px;
+    background-position: -2px -2px;
   }
 
   .aside-wrapper {
     display: none;
 
     @media screen and (min-width: 1024px) {
-      background-color: var(--backgroundColorSecondary);
-      border-radius: 4px;
-      border: 1px solid var(--borderPrimary);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
       display: block;
-      padding: 24px;
       position: sticky;
-      top: 24px;
+      top: 88px;
+      background: var(--backgroundColorSecondary);
+      border: 1px solid var(--borderPrimary);
+      border-radius: var(--radius-md);
+      padding: 22px 22px 20px;
     }
-  }
-</style>
-
-<style is:global>
-  img {
-    max-width: 100%;
-    border-radius: 8px;
-  }
-
-  h1 {
-    font-size: 2.5rem;
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-    color: var(--titleColor);
-  }
-
-  h2 {
-    font-size: 1.75rem;
-    margin-bottom: 1rem;
-    color: var(--titleColor);
-  }
-
-  h3 {
-    font-size: 1.25rem;
-    margin-bottom: 0.5rem;
-    color: var(--titleColor);
-  }
-
-  p {
-    margin-bottom: 1.5rem;
-    color: var(--textColor);
-    font-size: clamp(0.875rem, 0.75rem + 1.5vw, 1.125rem);
-  }
-
-  ul {
-    color: var(--textColor);
-    margin-bottom: 2.5rem;
-  }
-
-  li {
-    /* margin-bottom: 1rem; */
-    color: var(--textColor);
-    font-size: clamp(0.875rem, 0.75rem + 1.5vw, 1.125rem);
-  }
-
-  hr {
-    margin-bottom: 3rem;
-    margin-top: 2rem;
-  }
-
-  a {
-    text-decoration: none;
-    color: var(--articleLinkColor);
-    font-weight: 500;
-    transition: 0.4s color;
-
-    &:hover {
-      color: var(--articleLinkHoverColor);
-    }
-  }
-
-  p > code {
-    background-color: var(--codeBackgroundColor);
-    padding: 0.25rem;
-    color: var(--codeTextColor);
-  }
-
-  pre,
-  ul {
-    margin-bottom: 2rem;
-  }
-
-  blockquote {
-    padding-left: 2rem;
-    font-style: italic;
-  }
-
-  small {
-    font-size: 14px;
-    color: var(--textColor);
-    margin-bottom: 2.5rem;
-    display: block;
-  }
-
-  table {
-    border-collapse: collapse;
-    border: 2px solid var(--borderPrimary);
-    width: 100%;
-    text-align: left;
-  }
-
-  th,
-  td {
-    border: 1px solid var(--borderPrimary);
-    padding: 4px 8px;
-  }
-
-  thead {
-    background-color: var(--backgroundColorSecondary);
-  }
-
-  tbody > tr:nth-of-type(even) {
-    background-color: var(--backgroundColorSecondary);
   }
 </style>
 
 <script>
   import handleReadingTime from "../utils/estimateReadingTime";
+  import initArticleEnhancements from "../utils/articleEnhancements";
+
   handleReadingTime();
+  initArticleEnhancements();
 </script>

--- a/src/pages/articles/decouvrez-les-fiches-techniques.md
+++ b/src/pages/articles/decouvrez-les-fiches-techniques.md
@@ -15,10 +15,6 @@ draft: false
 publishedDate: 08/24/2024
 ---
 
-# Découvrez les fiches techniques
-
-![Quelqu'un assis dans un jardin au printemps, pixel art](/images/articles/triche-classe-exam.webp)
-
 ## La recherche du bon format
 
 Depuis l'annonce de la nouvelle version de NX, j'ai été un peu avare en
@@ -131,5 +127,3 @@ N'hésitez surtout pas à nous faire un retour via GitHub -
 permettra d'ouvrir une issue sur notre repository GitHub.
 
 ---
-
-Bonne lecture. <br> <span class="author">Thomas</span>

--- a/src/pages/articles/decouvrir-pico-8.md
+++ b/src/pages/articles/decouvrir-pico-8.md
@@ -17,6 +17,12 @@ author: Thomas
 draft: true
 publishedDate: 06/17/2026
 
+tags:
+  - Game dev
+  - PICO-8
+  - Carnet de bord
+  - Rétro
+
 faq:
   - question: PICO-8 est-il gratuit ?
     answer:
@@ -38,11 +44,6 @@ faq:
       devenus des jeux complets : Celeste, par exemple, a démarré comme un jeu
       PICO-8 avant sa version commerciale."
 ---
-
-# Découvrir PICO-8, la fantasy console pour créer des jeux
-
-![PICO-8, la fantasy console pour créer des jeux rétro, illustration pixel
-art](/images/articles/decouvrir-pico-8.webp)
 
 ## Comment j’ai découvert PICO-8 ?
 
@@ -281,6 +282,3 @@ commencent les plus belles histoires.
 - Le manuel officiel, qui couvre toute l'API ainsi que les fonctions des
   éditeurs intégrés :
   [le manuel PICO-8](https://www.lexaloffle.com/dl/docs/pico-8_manual.html).
-
-<br>
-<span class="author">Thomas</span>

--- a/src/pages/articles/gpt-meileur-ami.md
+++ b/src/pages/articles/gpt-meileur-ami.md
@@ -16,10 +16,6 @@ draft: false
 publishedDate: 02/09/2025
 ---
 
-# ChatGPT devient son meilleur ami, découvrez pourquoi
-
-![Un adolescent discutant dans sa chambre avec une IA, pixel art](/images/articles/ado-dialogue-ia.webp)
-
 Avouez-le, le titre de cet article vous a donné envie de cliquer ! Vous vous
 êtes sûrement dit : Quoi ? Mais comment peut-on lâcher ses amis pour ChatGPT ?
 

--- a/src/pages/articles/le-recap-aout-2025.md
+++ b/src/pages/articles/le-recap-aout-2025.md
@@ -17,12 +17,6 @@ draft: false
 publishedDate: 08/29/2025
 ---
 
-# Le récap #5 - Août 2025
-
-<img src="/images/articles/kiosque-journaux.webp" alt="Un vendeur de journaux dans un kiosque parisien, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
-<br>
-
 ## Foot, athlétisme ou ménage : les images des premiers Jeux mondiaux d’humanoïdes
 
 <small>Courrier international</small>

--- a/src/pages/articles/le-recap-avril-2025.md
+++ b/src/pages/articles/le-recap-avril-2025.md
@@ -15,12 +15,6 @@ draft: false
 publishedDate: 04/25/2025
 ---
 
-# Le récap #1 - Avril 2025
-
-<img src="/images/articles/kiosque-journaux.webp" alt="Un vendeur de journaux dans un kiosque parisien, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
-<br>
-
 ## Le lancement du récap sur NX
 
 <small>Par NX Academy</small>

--- a/src/pages/articles/le-recap-juillet-2025.md
+++ b/src/pages/articles/le-recap-juillet-2025.md
@@ -17,11 +17,6 @@ draft: false
 publishedDate: 07/25/2025
 ---
 
-# Le récap #4 - Juillet 2025
-
-<img src="/images/articles/kiosque-journaux.webp" alt="Un vendeur de journaux dans un kiosque parisien, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
-<br>
 
 ## ECMAScript 2025 : ce qui arrive bientôt en JavaScript
 

--- a/src/pages/articles/le-recap-juillet-2025.md
+++ b/src/pages/articles/le-recap-juillet-2025.md
@@ -17,7 +17,6 @@ draft: false
 publishedDate: 07/25/2025
 ---
 
-
 ## ECMAScript 2025 : ce qui arrive bientôt en JavaScript
 
 <small>Axel Rauschmayer</small>

--- a/src/pages/articles/le-recap-juin-2025.md
+++ b/src/pages/articles/le-recap-juin-2025.md
@@ -17,12 +17,6 @@ draft: false
 publishedDate: 06/27/2025
 ---
 
-# Le récap #3 - Juin 2025
-
-<img src="/images/articles/kiosque-journaux.webp" alt="Un vendeur de journaux dans un kiosque parisien, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
-<br>
-
 ## No Server, No Database: Smarter Related Posts in Astro with `transformers.js`
 
 <small>Alexander Opalic</small>

--- a/src/pages/articles/le-recap-mai-2025.md
+++ b/src/pages/articles/le-recap-mai-2025.md
@@ -16,12 +16,6 @@ draft: false
 publishedDate: 05/31/2025
 ---
 
-# Le récap #2 - Mai 2025
-
-<img src="/images/articles/kiosque-journaux.webp" alt="Un vendeur de journaux dans un kiosque parisien, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
-<br>
-
 ## My Experience with Next.js Why It's Bad (And Getting Worse)
 
 <small>Bharathvaj Ganesan</small>

--- a/src/pages/articles/le-recap-presentation.md
+++ b/src/pages/articles/le-recap-presentation.md
@@ -18,10 +18,6 @@ draft: false
 publishedDate: 04/25/2025
 ---
 
-# Facilitez votre veille technologique avec Le Recap
-
-<img src="/images/articles/scene-journalistes-journal.webp" alt="Une scène de rédaction dans un journal, des journalises sont occupés à écrire des articles, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
 Décidément, en ce moment, NX est bien vivant !
 
 Après plusieurs mois d’hibernation (six, pour être honnête mais, hein, c’était

--- a/src/pages/articles/le-recap-septembre-2025.md
+++ b/src/pages/articles/le-recap-septembre-2025.md
@@ -15,11 +15,6 @@ draft: false
 publishedDate: 09/26/2025
 ---
 
-# Le récap #6 - Septembre 2025
-
-<img src="/images/articles/kiosque-journaux.webp" alt="Un vendeur de journaux dans un kiosque parisien, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
-<br>
 
 ## Aidez-nous à collecter 200 000 $ pour libérer JavaScript d'Oracle
 

--- a/src/pages/articles/le-recap-septembre-2025.md
+++ b/src/pages/articles/le-recap-septembre-2025.md
@@ -15,7 +15,6 @@ draft: false
 publishedDate: 09/26/2025
 ---
 
-
 ## Aidez-nous à collecter 200 000 $ pour libérer JavaScript d'Oracle
 
 <small>Ryan Dahl</small>

--- a/src/pages/articles/nx-fait-des-jeux.md
+++ b/src/pages/articles/nx-fait-des-jeux.md
@@ -15,10 +15,6 @@ draft: false
 publishedDate: 04/01/2026
 ---
 
-# Comment je suis tombé dans le développement de jeux vidéo
-
-![Un joueur en train jouer à un city builder, pixel art](/images/articles/city-builder-player.webp)
-
 ## NX Academy se met aux jeux vidéo
 
 Voilà un article qui est assez peu difficile à expliquer et à introduire. Non
@@ -143,5 +139,3 @@ liens vers le code ou la page Steam selon le cas. C'est un espace qui va
 Je publierai des mises à jour au fil du temps. Si vous avez des questions sur un
 projet, une curiosité technique ou envie d'échanger, vous pouvez me retrouver
 [sur LinkedIn](https://www.linkedin.com/in/thomas-dimnet-4114a4147/).
-
-Bonne exploration. <br> <span class="author">Thomas</span>

--- a/src/pages/articles/point-nx-2025.md
+++ b/src/pages/articles/point-nx-2025.md
@@ -15,10 +15,6 @@ draft: false
 publishedDate: 01/25/2025
 ---
 
-# On fait le bilan ?
-
-![Des personnes faisant une réunion dans une salle, pixel art](/images/articles/reunion-point.webp)
-
 Bonne année 2025 à toutes et à tous ! Oui, je sais, on est déjà à la fin du mois
 de janvier, mais comme on dit : _il n’est jamais trop tard pour bien faire_. Et
 quoi de mieux que ce début d’année pour prendre un peu de recul, faire le point
@@ -176,6 +172,3 @@ Un grand merci pour votre soutien tout au long de cette aventure avec NX.
 
 On se retrouve très bientôt avec un nouvel article (allez, cette fois, on y
 croit vraiment !). En attendant, prenez soin de vous et surtout… codez bien !
-
-<br>
-<span class="author">Thomas</span>

--- a/src/pages/articles/profils-ia-developpeur.md
+++ b/src/pages/articles/profils-ia-developpeur.md
@@ -18,10 +18,6 @@ draft: false
 publishedDate: 03/29/2025
 ---
 
-# Le Moine, le Vape Coder, le Debugger & le Learner
-
-<img src="/images/articles/quatre-hommes-pose.webp" alt="Un moine, un jeune avec une capuche, un bucheron et un adolescent posant sur une photo, pixel art" style="aspect-ratio: 1792 / 1024; object-fit: cover; width: 100%; display: block; object-position: top" />
-
 Vous vous êtes déjà demandé le type de développeur que vous étiez ? Par exemple,
 est-ce que vous êtes le genre de dev qui accorde plus d’importance à la
 lisibilité du code ? Ou selon vous, la performance doit toujours passer en

--- a/src/pages/articles/projets-pour-2026.md
+++ b/src/pages/articles/projets-pour-2026.md
@@ -14,10 +14,6 @@ draft: false
 publishedDate: 01/01/2026
 ---
 
-# Quels projets pour NX en 2026 ?
-
-![Une bande de dévelloppeurs en train de jouer sur un télé, pixel art](/images/articles/dev-fetes-fin-annee.webp)
-
 Ça y est, nous sommes en 2026. Avant toute chose, **je vous souhaite une
 excellente année**. J’espère qu’elle sera à la hauteur de vos attentes, qu’elle
 vous apportera de la joie, et surtout du plaisir dans ce que vous ferez.
@@ -170,6 +166,3 @@ j’y aurai pris beaucoup de plaisir — et c’est probablement le plus importa
 pour moi.
 
 On se retrouve très bientôt !
-
-<br>
-<span class="author">Thomas</span>

--- a/src/pages/articles/review-nx-2025.md
+++ b/src/pages/articles/review-nx-2025.md
@@ -15,10 +15,6 @@ draft: false
 publishedDate: 12/27/2025
 ---
 
-# Bilan de l'année 2025 de NX
-
-![Un développeur en train de coder un Père Noel, pixel art](/images/articles/dev-pere-noel.webp)
-
 Comme l’année dernière, j’ai décidé de profiter des fêtes de fin d’année pour
 dresser le bilan de NX en 2025. C’est un exercice auquel je vais essayer de me
 plier tous les ans. A la fois parce que je pense que ça peut être intéressant
@@ -144,6 +140,3 @@ Vu la densité de cette année, je préfère finalement prendre le temps d’éc
 article dédié à ce qui arrive en 2026.
 
 On se retrouve l’année prochaine.
-
-<br>
-<span class="author">Thomas</span>

--- a/src/pages/articles/welcome-v2.md
+++ b/src/pages/articles/welcome-v2.md
@@ -15,10 +15,6 @@ draft: false
 publishedDate: 03/21/2024
 ---
 
-# Bienvenue sur la V2
-
-![Quelqu'un assis dans un jardin au printemps, pixel art](/images/articles/jardin-printemps.webp)
-
 ## Comme un parfum de printemps.
 
 Il y a maintenant un an (**edit d'avril 2025 : ça fait maintenant 2 ans !**), je
@@ -121,4 +117,3 @@ remontent.
 ---
 
 Bienvenue sur la nouvelle version de <span class="brand-name">NX Academy</span>.
-<br> <span class="author">Thomas</span>

--- a/src/pages/fiches/bien-faire-multi-stage-build.md
+++ b/src/pages/fiches/bien-faire-multi-stage-build.md
@@ -18,12 +18,6 @@ level: Avancé
 publishedDate: 09/12/2025
 ---
 
-<article>
-
-# Comment faire <br> un multi-stage build ?
-
-![Une scène d'immeubles avec 6 appartements où l'intérieur est visible, pixel art](/images/cheatsheets/scene-immeuble.webp)
-
 Avant de commencer, sachez que
 [le cours sur Docker et Docker Compose](/cours/docker-et-docker-compose/) est
 actuellement disponible sur NX Academy. Je vais continuer à publier des fiches
@@ -287,4 +281,3 @@ D’ici là :
 - [How to Build Smaller Container Images: Docker Multi-Stage Builds](https://labs.iximiuz.com/tutorials/docker-multi-stage-builds)
 - [Docker Multi-Stage Builds: An In-depth Guide](https://ercanermis.com/docker-multi-stage-builds-an-in-depth-guide/)
 
-</article>

--- a/src/pages/fiches/bien-faire-multi-stage-build.md
+++ b/src/pages/fiches/bien-faire-multi-stage-build.md
@@ -280,4 +280,3 @@ D’ici là :
 - [Multistage Image Builds in Docker: A Comprehensive Guide from Basics to Mastery](https://medium.com/@lexitrainerph/multistage-image-builds-in-docker-a-comprehensive-guide-from-basics-to-mastery-5884b547950)
 - [How to Build Smaller Container Images: Docker Multi-Stage Builds](https://labs.iximiuz.com/tutorials/docker-multi-stage-builds)
 - [Docker Multi-Stage Builds: An In-depth Guide](https://ercanermis.com/docker-multi-stage-builds-an-in-depth-guide/)
-

--- a/src/pages/fiches/bien-utiliser-volumes-docker.md
+++ b/src/pages/fiches/bien-utiliser-volumes-docker.md
@@ -15,12 +15,6 @@ level: Intermédiaire
 publishedDate: 05/02/2025
 ---
 
-<article>
-
-# Comment (bien) utiliser les volumes Docker ?
-
-![Une femme en train de brancher une clé USB dans un ordinateur, pixel art](/images/cheatsheets/femme-cle-usb.webp)
-
 La sortie du cours sur Docker approche à grand pas. Pour cette occasion, sachez
 que **les quatre prochaines fiches techniques seront dédiées à cet outil**.
 C'est, selon moi, un indispensable à connaître.
@@ -186,4 +180,3 @@ registries Docker !
 - [Travailler avec les volumes Docker - LabEx](https://labex.io/fr/tutorials/docker-working-with-docker-volumes-389189)
 - [La documentation officielle sur les bind mounts Docker](https://docs.docker.com/get-started/workshop/06_bind_mounts/)
 
-</article>

--- a/src/pages/fiches/bien-utiliser-volumes-docker.md
+++ b/src/pages/fiches/bien-utiliser-volumes-docker.md
@@ -179,4 +179,3 @@ registries Docker !
 - [La documentation officielle sur les volumes Docker](https://docs.docker.com/engine/storage/volumes/)
 - [Travailler avec les volumes Docker - LabEx](https://labex.io/fr/tutorials/docker-working-with-docker-volumes-389189)
 - [La documentation officielle sur les bind mounts Docker](https://docs.docker.com/get-started/workshop/06_bind_mounts/)
-

--- a/src/pages/fiches/comprendre-l-asynchrone-en-javascript.md
+++ b/src/pages/fiches/comprendre-l-asynchrone-en-javascript.md
@@ -14,15 +14,9 @@ imgSrc: /images/cheatsheets/asynchrone-js.webp
 
 author: Lionel
 kind: Fiche technique
-level: Intémediaire
+level: Intermédiaire
 publishedDate: 09/15/2024
 ---
-
-<article>
-
-# Comprendre l'Asynchrone en JavaScript 🚀
-
-![Une personne multitâche au bureau avec un symbole de boucle infinie, pixel art](/images/cheatsheets/asynchrone-js.webp)
 
 ## JavaScript est-il asynchrone ? ⏱️
 
@@ -206,4 +200,3 @@ les pizzas et le code fluide ! 🍕💻
 - [JavaScript: The Good Parts - Eloquent JavaScript (Chapitre sur les Promises)](https://eloquentjavascript.net/11_async.html)
 - [Exploration de l'Event Loop avec des exemples interactifs - Loupe](http://latentflip.com/loupe/)
 
- </article>

--- a/src/pages/fiches/comprendre-l-asynchrone-en-javascript.md
+++ b/src/pages/fiches/comprendre-l-asynchrone-en-javascript.md
@@ -199,4 +199,3 @@ les pizzas et le code fluide ! 🍕💻
 - [Différences entre les callbacks, les promises et async/await - Blog de Flavio Copes](https://flaviocopes.com/javascript-async-await/)
 - [JavaScript: The Good Parts - Eloquent JavaScript (Chapitre sur les Promises)](https://eloquentjavascript.net/11_async.html)
 - [Exploration de l'Event Loop avec des exemples interactifs - Loupe](http://latentflip.com/loupe/)
-

--- a/src/pages/fiches/comprendre-la-fonction-css-clamp.md
+++ b/src/pages/fiches/comprendre-la-fonction-css-clamp.md
@@ -165,4 +165,3 @@ projets :).
 - [Modern Fluid Typography Using CSS Clamp](https://www.smashingmagazine.com/2022/01/modern-fluid-typography-css-clamp/)
 - [CSS math functions min(), max() and clamp()](https://caniuse.com/css-math-functions)
 - [An accessible fluid type generator](https://fluid.style/type?min=1&max=1.125&min-bp=2&max-bp=90&unit=%22rem%22)
-

--- a/src/pages/fiches/comprendre-la-fonction-css-clamp.md
+++ b/src/pages/fiches/comprendre-la-fonction-css-clamp.md
@@ -16,12 +16,6 @@ author: Thomas
 publishedDate: 07/17/2024
 ---
 
-<article>
-
-# Comprendre la fonction CSS Clamp
-
-![Quelqu'un mesurant un salon avec un mètre, pixel art](/images/cheatsheets/homme-mesure-salon.webp)
-
 J'ai récemment travaillé sur un projet
 [dans le cadre du parcours "Building Responsive Layouts"](https://www.frontendmentor.io/learning-paths/building-responsive-layouts--z1qCXVqkD)
 de Frontend Mentor. Comme tous les parcours de Frontend Mentor, celui-ci inclut
@@ -172,4 +166,3 @@ projets :).
 - [CSS math functions min(), max() and clamp()](https://caniuse.com/css-math-functions)
 - [An accessible fluid type generator](https://fluid.style/type?min=1&max=1.125&min-bp=2&max-bp=90&unit=%22rem%22)
 
-</article>

--- a/src/pages/fiches/comprendre-le-mot-clef-this.md
+++ b/src/pages/fiches/comprendre-le-mot-clef-this.md
@@ -15,12 +15,6 @@ level: Débutant
 publishedDate: 08/22/2024
 ---
 
-<article>
-
-# Comprendre le mot clef "this"
-
-![Deux personnes dans une cuisine séparée, pixel art](/images/cheatsheets/scene-duo-ambiance.webp)
-
 J'ai récemment été confronté à l'utilisation du mot clé this
 [dans un cours sur le JavaScript sur Udemy](https://www.udemy.com/course/pro-javascript/).
 Le cours proposait de réaliser un jeu de Puissance 4 en programmation orienté
@@ -493,4 +487,3 @@ compréhension de ce petit mot si crucial !
 - [Articles JavaScript - GeeksforGeeks](https://www.geeksforgeeks.org/)
 - [Guide sur `this` et l'orientation objet - JavaScript.info](https://javascript.info/object-methods#method-this)
 - [Tutoriels JavaScript - Dyma](https://dyma.fr/cours/javascript)
-</article>

--- a/src/pages/fiches/comprendre-les-proxys-et-reverse-proxys.md
+++ b/src/pages/fiches/comprendre-les-proxys-et-reverse-proxys.md
@@ -17,12 +17,6 @@ author: Yacine
 publishedDate: 10/03/2024
 ---
 
-<article>
-
-# Comprendre les proxys et reverses proxys
-
-![Un serveur dans un café parisien, pixel art](/images/cheatsheets/serveur-parisien.webp)
-
 En informatique, un proxy et un reverse proxy sont des types de serveurs. Pour
 bien comprendre ce qu’est un proxy et un reverse proxy, il faut d'abord
 comprendre globalement ce qu’est un serveur et un client.
@@ -205,4 +199,3 @@ Installé au sein de l'architecture serveur, il distribue les requêtes entre
 plusieurs serveurs, améliore la sécurité en cachant les serveurs principaux, et
 optimise les performances globales de l'application.
 
-</article>

--- a/src/pages/fiches/comprendre-les-proxys-et-reverse-proxys.md
+++ b/src/pages/fiches/comprendre-les-proxys-et-reverse-proxys.md
@@ -198,4 +198,3 @@ performances grâce à la mise en cache des données.
 Installé au sein de l'architecture serveur, il distribue les requêtes entre
 plusieurs serveurs, améliore la sécurité en cachant les serveurs principaux, et
 optimise les performances globales de l'application.
-

--- a/src/pages/fiches/comprendre-next-image-avec-storybook.md
+++ b/src/pages/fiches/comprendre-next-image-avec-storybook.md
@@ -17,12 +17,6 @@ level: Intermédiaire
 publishedDate: 11/30/2024
 ---
 
-<article>
-
-# Utilisation du composant "next/image" avec Storybook et TypeScript 📕🛠️📘
-
-![Un ingénieur travaillant sur le pontage de pipeline en extérieur, pixel art](/images/cheatsheets/ingenieur-pontage-pipeline.webp)
-
 ## Problématique 🚨
 
 Lorsque j'ai débuté un projet NextJS avec TypeScript et Storybook, j'ai très

--- a/src/pages/fiches/declencher-workflow-github-actions.md
+++ b/src/pages/fiches/declencher-workflow-github-actions.md
@@ -357,4 +357,3 @@ En attendant :
 - [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
 - [Building a workflow with GitHub Actions](https://resources.github.com/learn/pathways/automation/essentials/building-a-workflow-with-github-actions/)
 - [Learn to Use GitHub Actions: a Step-by-Step Guide](https://www.freecodecamp.org/news/learn-to-use-github-actions-step-by-step-guide/)
-

--- a/src/pages/fiches/declencher-workflow-github-actions.md
+++ b/src/pages/fiches/declencher-workflow-github-actions.md
@@ -20,12 +20,6 @@ level: Débutant
 publishedDate: 10/02/2025
 ---
 
-<article>
-
-# Quand et comment déclencher un workflow GitHub Actions ?
-
-![Une scène avec des tapis roulants et des usines avec pour inspiration Satisfactory, pixel art](/images/cheatsheets/usine-tapis-roulant.webp)
-
 Je vous l'avais promis ! Je commence à faire la transition vers un autre grand
 classique de la boîte à outils DevOps : les CI serveurs.
 
@@ -364,4 +358,3 @@ En attendant :
 - [Building a workflow with GitHub Actions](https://resources.github.com/learn/pathways/automation/essentials/building-a-workflow-with-github-actions/)
 - [Learn to Use GitHub Actions: a Step-by-Step Guide](https://www.freecodecamp.org/news/learn-to-use-github-actions-step-by-step-guide/)
 
-</article>

--- a/src/pages/fiches/intro-a-pygame.md
+++ b/src/pages/fiches/intro-a-pygame.md
@@ -293,4 +293,3 @@ instructions d'installation pour macOS, Linux et Windows.
 - [La documentation officielle de Pygame](https://www.pygame.org/docs/)
 - [Game Programming Patterns — Bob Nystrom](https://gameprogrammingpatterns.com/game-loop.html)
 - [Code the Classics — Raspberry Pi Foundation](https://codeclassics.raspberrypi.com/)
-

--- a/src/pages/fiches/intro-a-pygame.md
+++ b/src/pages/fiches/intro-a-pygame.md
@@ -16,12 +16,6 @@ level: Débutant
 publishedDate: 03/07/2026
 ---
 
-<article>
-
-# Comment débuter avec Pygame ?
-
-![Un développeur devant de nombreux écrans, pixel art](/images/cheatsheets/developpeur-devant-ecrans.webp)
-
 Si vous avez lu [mon bilan](/articles/review-nx-2025) ou mes
 [projets pour 2026](/articles/projets-pour-2026), vous avez peut-être remarqué
 que je n'en avais pas parlé. Et pourtant, depuis octobre 2025, je code des jeux
@@ -300,4 +294,3 @@ instructions d'installation pour macOS, Linux et Windows.
 - [Game Programming Patterns — Bob Nystrom](https://gameprogrammingpatterns.com/game-loop.html)
 - [Code the Classics — Raspberry Pi Foundation](https://codeclassics.raspberrypi.com/)
 
-</article>

--- a/src/pages/fiches/les-retours-de-fonction-en-javascript.md
+++ b/src/pages/fiches/les-retours-de-fonction-en-javascript.md
@@ -202,4 +202,3 @@ console.log("Le total de la commande est : " + totalCommande + " euros.");
 - [Le mot-clé "return" (FR) - MDN](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Statements/return)
 - [JavaScript Functions (EN) - W3Schools](https://www.w3schools.com/js/js_functions.asp)
 - [JavaScript Return Statement (EN) - W3Schools](https://www.w3schools.com/jsref/jsref_return.asp)
-

--- a/src/pages/fiches/les-retours-de-fonction-en-javascript.md
+++ b/src/pages/fiches/les-retours-de-fonction-en-javascript.md
@@ -20,12 +20,6 @@ author: Oumar
 publishedDate: 10/18/2024
 ---
 
-<article>
-
-# Les retours de fonction en Javascript
-
-![un jeune programmeur assis devant un ordinateur rétro, en train de coder des valeurs de retour en javaScript, pixel art](/images/cheatsheets/jeune-programmeur-code.webp)
-
 A nos débuts en Javascript après avoir compris les types de données primitifs
 (Number, String, Boolean, undefined et Null), on a tendance à se jeter sur les
 fonctions et les manipuler directement sans vraiment comprendre une notion clé
@@ -209,4 +203,3 @@ console.log("Le total de la commande est : " + totalCommande + " euros.");
 - [JavaScript Functions (EN) - W3Schools](https://www.w3schools.com/js/js_functions.asp)
 - [JavaScript Return Statement (EN) - W3Schools](https://www.w3schools.com/jsref/jsref_return.asp)
 
-</article>

--- a/src/pages/fiches/optimisation-images-docker.md
+++ b/src/pages/fiches/optimisation-images-docker.md
@@ -11,15 +11,9 @@ imgSrc: /images/cheatsheets/magasin-chinois.webp
 
 author: Thomas
 kind: Fiche technique
-level: intermediaire
+level: Intermédiaire
 publishedDate: 07/04/2025
 ---
-
-<article>
-
-# Comment optimiser une image Docker ?
-
-![Une vendeuse asiatique utilisant un balance dans un magasin, pixel art](/images/cheatsheets/magasin-chinois.webp)
 
 Ca y est : le cours sur Docker
 [est officiellement disponible](/cours/docker-et-docker-compose) ! Si ce n’est
@@ -299,4 +293,3 @@ D'ici là, je vous invite :
 - [How I Cut Docker Image Size by 90%: Best Practices for Lean Containers](https://medium.com/@ksaquib/how-i-cut-docker-image-size-by-90-best-practices-for-lean-containers-1f705cead02b)
 - [13 Ways to Optimize Docker Builds](https://overcast.blog/13-ways-to-optimize-docker-builds-ba1151b256f3)
 
-</article>

--- a/src/pages/fiches/optimisation-images-docker.md
+++ b/src/pages/fiches/optimisation-images-docker.md
@@ -292,4 +292,3 @@ D'ici là, je vous invite :
 - [How to Reduce Docker Image Size: 6 Optimization Methods](/https://devopscube.com/reduce-docker-image-size/)
 - [How I Cut Docker Image Size by 90%: Best Practices for Lean Containers](https://medium.com/@ksaquib/how-i-cut-docker-image-size-by-90-best-practices-for-lean-containers-1f705cead02b)
 - [13 Ways to Optimize Docker Builds](https://overcast.blog/13-ways-to-optimize-docker-builds-ba1151b256f3)
-

--- a/src/pages/fiches/presentation-registry-docker.md
+++ b/src/pages/fiches/presentation-registry-docker.md
@@ -17,12 +17,6 @@ level: Intermédiaire
 publishedDate: 06/06/2025
 ---
 
-<article>
-
-# Qu'est-ce qu'un registry Docker?
-
-![Une installation portuaire où un bateau est en train d'être déchargé de ses conteneurs, pixel art](/images/cheatsheets/registry-docker.webp)
-
 On continue notre série dédiée à Docker avec les registries Docker. Je me suis
 rendu compte que j'avais abordé ce concept dans le cours sans vraiment faire un
 chapitre dédié. Cette fiche technique est l'occasion de revenir sur cette notion
@@ -322,4 +316,3 @@ avez bien compris ce qu'on vient de voir.
 - [Docker tag – Référence CLI](https://docs.docker.com/reference/cli/docker/image/tag/)
 - [Configurer un registry privé Docker](https://devopssec.fr/article/deployer-manipuler-securiser-un-serveur-registry-docker-prive)
 
-</article>

--- a/src/pages/fiches/presentation-registry-docker.md
+++ b/src/pages/fiches/presentation-registry-docker.md
@@ -315,4 +315,3 @@ avez bien compris ce qu'on vient de voir.
 - [Docker push – Référence CLI](https://docs.docker.com/reference/cli/docker/image/push/)
 - [Docker tag – Référence CLI](https://docs.docker.com/reference/cli/docker/image/tag/)
 - [Configurer un registry privé Docker](https://devopssec.fr/article/deployer-manipuler-securiser-un-serveur-registry-docker-prive)
-

--- a/src/styles/article-content.css
+++ b/src/styles/article-content.css
@@ -1,0 +1,238 @@
+/* ============================================================================
+   Styles de lecture partagés entre les articles (BlogPostLayout) et les fiches
+   techniques (CheatSheetsLayout). Fidèles à la maquette V1+, pilotés par les
+   tokens du dépôt → compatibles dark / light / summer. Importé globalement par
+   les deux layouts ; tout est scopé à `.prose` (contenu markdown) ou aux
+   utilitaires d'article, pour ne pas déteindre sur le reste du site.
+   ============================================================================ */
+
+/* --- Barre de progression fine (haut de page) ----------------------------- */
+.nx-progress-top {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 200;
+  background: transparent;
+  pointer-events: none;
+}
+.nx-progress-top::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 100%;
+  transform: scaleX(var(--p, 0));
+  transform-origin: 0 50%;
+  background: var(--buttonColorPrimary);
+  transition: transform 0.08s linear;
+}
+
+/* --- Signature de fin d'article ------------------------------------------- */
+.article-signoff {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  color: var(--titleColor);
+  margin: 2rem 0 0;
+}
+
+/* ==========================================================================
+   Typographie de lecture (.prose)
+   ========================================================================== */
+.prose h2 {
+  font-family: var(--font-heading);
+  color: var(--titleColor);
+  font-size: clamp(1.5rem, 1.2rem + 1vw, 1.9rem);
+  line-height: 1.2;
+  margin: 0 0 1.1rem;
+  scroll-margin-top: 88px;
+}
+.prose h3 {
+  font-family: var(--font-heading);
+  color: var(--titleColor);
+  font-size: 1.25rem;
+  line-height: 1.3;
+  margin: 1.6rem 0 0.6rem;
+}
+.prose p {
+  font-size: clamp(1rem, 0.95rem + 0.25vw, 1.12rem);
+  line-height: 1.7;
+  margin: 0 0 1.35rem;
+  color: var(--textColor);
+  text-wrap: pretty;
+}
+.prose p strong,
+.prose li strong {
+  color: var(--titleColor);
+  font-weight: 600;
+}
+.prose a {
+  color: var(--articleLinkColor);
+  text-decoration: none;
+  font-weight: 500;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--articleLinkColor) 35%, transparent);
+  transition:
+    color var(--transition),
+    border-color var(--transition);
+}
+.prose a:hover {
+  color: var(--articleLinkHoverColor);
+  border-color: var(--articleLinkHoverColor);
+}
+.prose ul {
+  margin: 0 0 1.6rem;
+  padding-left: 1.1rem;
+}
+.prose li {
+  font-size: clamp(1rem, 0.95rem + 0.25vw, 1.12rem);
+  line-height: 1.65;
+  margin-bottom: 0.6rem;
+  color: var(--textColor);
+}
+.prose li::marker {
+  color: var(--buttonColorPrimary);
+}
+.prose em {
+  font-style: italic;
+}
+.prose hr {
+  border: none;
+  border-top: 1px solid var(--borderPrimary);
+  margin: 2rem 0;
+}
+.prose img {
+  width: 100%;
+  border-radius: var(--radius-md);
+  margin: 0 0 1.5rem;
+}
+
+/* Code en ligne — remplissage néon plein (signature NX) */
+.prose :not(pre) > code {
+  font-family: var(--font-mono);
+  background: var(--codeBackgroundColor);
+  color: var(--codeTextColor);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-sm);
+  font-size: 0.88em;
+}
+/* Bloc de code */
+.prose pre {
+  position: relative;
+  background: color-mix(
+    in srgb,
+    var(--backgroundColorSecondary) 55%,
+    var(--backgroundColorPrimary)
+  );
+  border: 1px solid var(--borderPrimary);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+  overflow: auto;
+  margin: 0 0 1.6rem;
+}
+.prose pre code {
+  font-family: var(--font-mono);
+  color: var(--titleColor);
+  font-size: 0.9rem;
+  line-height: 1.65;
+  background: none;
+  padding: 0;
+  white-space: pre;
+}
+
+/* Citation en exergue (reprise de la maquette V2) */
+.prose blockquote {
+  position: relative;
+  border-left: none;
+  margin: 2.4rem 0;
+  padding: 0.5rem 0 0.5rem 3rem;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  line-height: 1.42;
+  color: var(--titleColor);
+  font-style: normal;
+}
+.prose blockquote::before {
+  content: "\201C";
+  position: absolute;
+  left: -2px;
+  top: -0.5rem;
+  font-family: var(--font-heading);
+  font-size: 4rem;
+  color: var(--accent);
+  line-height: 1;
+}
+.prose blockquote p {
+  margin: 0;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+/* Tableaux (surtout utiles aux fiches techniques) */
+.prose table {
+  border-collapse: collapse;
+  border: 2px solid var(--borderPrimary);
+  width: 100%;
+  text-align: left;
+  margin: 0 0 1.6rem;
+  font-size: 0.95rem;
+}
+.prose th,
+.prose td {
+  border: 1px solid var(--borderPrimary);
+  padding: 6px 10px;
+  color: var(--textColor);
+}
+.prose thead {
+  background-color: var(--backgroundColorSecondary);
+}
+.prose thead th {
+  color: var(--titleColor);
+}
+.prose tbody > tr:nth-of-type(even) {
+  background-color: var(--backgroundColorSecondary);
+}
+
+/* Bouton « copier » injecté dans les blocs de code */
+.nx-copy {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  color: var(--textColor);
+  background: color-mix(in srgb, var(--backgroundColorPrimary) 80%, transparent);
+  border: 1px solid var(--borderPrimary);
+  border-radius: 6px;
+  padding: 4px 9px;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+.prose pre:hover .nx-copy,
+.nx-copy:focus-visible {
+  opacity: 1;
+}
+.nx-copy:hover,
+.nx-copy.copied {
+  color: var(--buttonColorPrimary);
+  border-color: var(--buttonColorPrimary);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    scroll-behavior: auto !important;
+  }
+  .nx-progress-top::after {
+    transition: none;
+  }
+}

--- a/src/styles/article-content.css
+++ b/src/styles/article-content.css
@@ -202,7 +202,11 @@
   letter-spacing: 0.02em;
   cursor: pointer;
   color: var(--textColor);
-  background: color-mix(in srgb, var(--backgroundColorPrimary) 80%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--backgroundColorPrimary) 80%,
+    transparent
+  );
   border: 1px solid var(--borderPrimary);
   border-radius: 6px;
   padding: 4px 9px;

--- a/src/styles/article-content.css
+++ b/src/styles/article-content.css
@@ -70,15 +70,10 @@
   color: var(--articleLinkColor);
   text-decoration: none;
   font-weight: 500;
-  border-bottom: 1px solid
-    color-mix(in srgb, var(--articleLinkColor) 35%, transparent);
-  transition:
-    color var(--transition),
-    border-color var(--transition);
+  transition: color var(--transition);
 }
 .prose a:hover {
   color: var(--articleLinkHoverColor);
-  border-color: var(--articleLinkHoverColor);
 }
 .prose ul {
   margin: 0 0 1.6rem;

--- a/src/types/Article.ts
+++ b/src/types/Article.ts
@@ -5,8 +5,11 @@ export type Article = {
     draft: boolean;
     imgAlt: string;
     imgSrc: string;
+    kind?: string;
     publishedDate: string;
     title: string;
+    tags?: string[];
+    faq?: { question: string; answer: string }[];
   };
   url: string;
 };

--- a/src/types/Cheatsheet.ts
+++ b/src/types/Cheatsheet.ts
@@ -5,9 +5,12 @@ export type Cheatsheet = {
     draft: boolean;
     imgAlt: string;
     imgSrc: string;
+    kind?: string;
     level: string;
     publishedDate: string;
     title: string;
+    faq?: { question: string; answer: string }[];
+    howTo?: { name?: string; steps: { name: string; text: string }[] };
   };
   url: string;
 };

--- a/src/utils/articleEnhancements/index.ts
+++ b/src/utils/articleEnhancements/index.ts
@@ -4,32 +4,34 @@
 // Adapté de la référence de design `article-shared.js`, en TypeScript.
 
 function addCopyButtons(): void {
-  document.querySelectorAll<HTMLPreElement>("[data-prose] pre").forEach((pre) => {
-    if (pre.querySelector(".nx-copy")) return;
+  document
+    .querySelectorAll<HTMLPreElement>("[data-prose] pre")
+    .forEach((pre) => {
+      if (pre.querySelector(".nx-copy")) return;
 
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "nx-copy";
-    btn.textContent = "Copier";
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "nx-copy";
+      btn.textContent = "Copier";
 
-    btn.addEventListener("click", () => {
-      const code = pre.querySelector("code") ?? pre;
-      if (!navigator.clipboard) return;
+      btn.addEventListener("click", () => {
+        const code = pre.querySelector("code") ?? pre;
+        if (!navigator.clipboard) return;
 
-      navigator.clipboard
-        .writeText((code.textContent ?? "").trim())
-        .then(() => {
-          btn.textContent = "Copié ✓";
-          btn.classList.add("copied");
-          setTimeout(() => {
-            btn.textContent = "Copier";
-            btn.classList.remove("copied");
-          }, 1600);
-        });
+        navigator.clipboard
+          .writeText((code.textContent ?? "").trim())
+          .then(() => {
+            btn.textContent = "Copié ✓";
+            btn.classList.add("copied");
+            setTimeout(() => {
+              btn.textContent = "Copier";
+              btn.classList.remove("copied");
+            }, 1600);
+          });
+      });
+
+      pre.appendChild(btn);
     });
-
-    pre.appendChild(btn);
-  });
 }
 
 function pageProgress(): number {

--- a/src/utils/articleEnhancements/index.ts
+++ b/src/utils/articleEnhancements/index.ts
@@ -1,0 +1,79 @@
+// Comportements client de la page de lecture d'article :
+//  • bouton « copier » injecté dans chaque bloc de code,
+//  • barre de progression fine en haut + barre à segments du sommaire + %.
+// Adapté de la référence de design `article-shared.js`, en TypeScript.
+
+function addCopyButtons(): void {
+  document.querySelectorAll<HTMLPreElement>("[data-prose] pre").forEach((pre) => {
+    if (pre.querySelector(".nx-copy")) return;
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "nx-copy";
+    btn.textContent = "Copier";
+
+    btn.addEventListener("click", () => {
+      const code = pre.querySelector("code") ?? pre;
+      if (!navigator.clipboard) return;
+
+      navigator.clipboard
+        .writeText((code.textContent ?? "").trim())
+        .then(() => {
+          btn.textContent = "Copié ✓";
+          btn.classList.add("copied");
+          setTimeout(() => {
+            btn.textContent = "Copier";
+            btn.classList.remove("copied");
+          }, 1600);
+        });
+    });
+
+    pre.appendChild(btn);
+  });
+}
+
+function pageProgress(): number {
+  const doc = document.documentElement;
+  const max = doc.scrollHeight - doc.clientHeight;
+  return max > 0 ? Math.min(1, Math.max(0, doc.scrollTop / max)) : 0;
+}
+
+function initProgress(): void {
+  const bars = document.querySelectorAll<HTMLElement>("[data-progress]");
+  const pct = document.querySelector<HTMLElement>(".outline-pct");
+  const segs = Array.from(
+    document.querySelectorAll<HTMLElement>(".outline-seg"),
+  );
+
+  if (!bars.length && !pct && !segs.length) return;
+
+  function update() {
+    const p = pageProgress();
+
+    bars.forEach((bar) => bar.style.setProperty("--p", p.toFixed(4)));
+
+    if (pct) pct.textContent = `${Math.round(p * 100)}%`;
+
+    if (segs.length) {
+      const lit = Math.round(p * segs.length);
+      segs.forEach((seg, i) => seg.classList.toggle("on", i < lit));
+    }
+  }
+
+  update();
+  window.addEventListener("scroll", update, { passive: true });
+  window.addEventListener("resize", update);
+}
+
+export default function initArticleEnhancements(): void {
+  function boot() {
+    addCopyButtons();
+    initProgress();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+}

--- a/src/utils/estimateReadingTime/index.ts
+++ b/src/utils/estimateReadingTime/index.ts
@@ -8,20 +8,27 @@ function calculateReadingTime(text: string, wordsPerMinute: number): number {
 export default function displayEstimatedReadingTime() {
   window.addEventListener("DOMContentLoaded", function () {
     const $article = document.querySelector("article");
+
+    if (!$article || !$article.textContent) return;
+
+    const readingTime = calculateReadingTime($article.textContent, 200);
+
+    // Page de lecture d'article : on alimente la pastille du byline.
+    const $pill = document.querySelector<HTMLElement>("[data-reading-min]");
+    if ($pill) {
+      $pill.textContent = `${readingTime} min`;
+      return;
+    }
+
+    // Repli (pages sans en-tête éditorial) : ancien comportement.
     const $articleTitle = document.querySelector("h1");
-
-    if ($article && $article.textContent) {
-      const readingTime = calculateReadingTime($article.textContent, 200);
-
+    if ($articleTitle) {
       const $timeInfo = document.createElement("small");
       $timeInfo.textContent = `Temps de lecture estimé : ${readingTime} minutes`;
-
-      if ($articleTitle) {
-        $articleTitle.parentNode?.insertBefore(
-          $timeInfo,
-          $articleTitle.nextSibling,
-        );
-      }
+      $articleTitle.parentNode?.insertBefore(
+        $timeInfo,
+        $articleTitle.nextSibling,
+      );
     }
   });
 }


### PR DESCRIPTION
## Overview

This PR introduces a comprehensive redesign of the blog post layout to distinguish between true articles (with editorial metadata) and other pages (like the manifesto). Articles now feature a professional editorial header, reading progress indicators, author cards, related articles, and share buttons.

## Key Changes

### Layout & Components
- **BlogPostLayout.astro**: Refactored to conditionally render article-specific UI based on a new `kind` frontmatter field
  - Added editorial header with kicker, title, description, byline (author/date), reading time pill, and tags
  - Added hero image support in the header
  - Integrated new components: `AuthorCard`, `RelatedArticles`, `ShareButtons`
  - Added article signoff section
  - Implemented dotted background pattern for article prose
  - Fixed progress bar and sidebar sticky positioning

- **New Components**:
  - `AuthorCard.astro`: Displays author bio with follow/articles links
  - `RelatedArticles.astro`: Auto-fetches and displays 3 most recent articles (excluding current)
  - `ShareButtons.astro`: LinkedIn share + copy-to-clipboard functionality

### Reading Enhancements
- **articleEnhancements/index.ts** (new): Client-side utilities for:
  - Copy buttons on code blocks
  - Top progress bar (`--p` CSS variable)
  - Sidebar progress segments with percentage display
  
- **StickyOutline.astro**: Enhanced with:
  - Optional numbered section entries (02, 03, etc.)
  - Progress bar with 12 segments
  - Left border indicator for active section
  - Improved scroll offset calculation per page type

### Frontmatter & Types
- Added `kind` field to distinguish articles from other pages
- Added `tags` array for article categorization
- Updated `Article` type to include new fields
- All article markdown files updated to remove h1/hero from content (now in layout)

### Styling
- **theme.css**: Added shared design tokens (radius, container, transitions, fonts)
- **BlogPostLayout.astro styles**:
  - Editorial header styling (kicker, byline, reading pill, tags, hero)
  - Prose-specific typography with improved readability
  - Code block styling with copy button
  - Blockquote styling with decorative quote mark
  - Progress bar and segment styling
  - Responsive grid layout (65/35 → 1fr/320px on desktop)

- **Faq.astro**: Converted to accordion pattern with `<details>/<summary>` and chevron animation

### Typography & Prose
- Dedicated `.prose` class for article-specific typography
- Improved font sizing with `clamp()` for responsive scaling
- Enhanced link styling with underline and hover states
- Better list and code block presentation
- Blockquote styling with accent color quote mark

## Migration Notes
- Pages without `kind` field retain original rendering (e.g., manifesto)
- Article h1 and hero images moved from markdown to layout—update existing articles by removing these elements from content
- Reading time now displays in byline pill instead of below title
- FAQ section now uses accordion pattern

## Testing
- Verify article pages render with editorial header, byline, and tags
- Verify non-article pages (manifesto) render without editorial UI
- Test copy-to-clipboard on code blocks
- Test progress bar and sidebar segments on scroll
- Verify related articles load and exclude current article
- Test share buttons (LinkedIn, copy link)
- Verify responsive layout on mobile/tablet/desktop

## Checklist
- [ ] Changelog updated
- [ ] All article markdown files migrated (h1/hero removed from content)

https://claude.ai/code/session_01WFFkRTyBnLCF7Q6vze9wZZ