### PR TITLE
Ajoute le changelog de juillet 2026

### DIFF
--- a/src/content/changelog/2026-06.yaml
+++ b/src/content/changelog/2026-06.yaml
@@ -1,0 +1,49 @@
+month: Juin
+year: 2026
+order: 6
+tasks:
+  - kind: done
+    content: |-
+      Grosse refonte de <a href="/articles" target="_blank">la page des articles</a> : filtres, tri et gestion des séries. On s'y retrouve beaucoup mieux.
+  - kind: done
+    content: |-
+      Sortie du <a href="/articles/le-recap-juin-2026" target="_blank">récap #7 (juin 2026)</a>. La série continue !
+  - kind: done
+    content: |-
+      Refonte aussi de <a href="/fiches" target="_blank">la page des fiches techniques</a> : séries, recherche et filtres.
+  - kind: done
+    content: |-
+      Publication de <a href="/articles/decouvrir-pico-8" target="_blank">l'article « Découvrir PICO-8 »</a>, la fantasy console pour créer des jeux.
+  - kind: in-progress
+    content: |-
+      Je prépare toute une série autour de PICO-8 (prise en main, premier jeu, PICO-8 vs Pygame, top 10…). Encore en brouillon.
+  - kind: in-progress
+    content: |-
+      Nouveaux guides Docker en préparation : Docker Swarm, gestion des réseaux et des secrets. En cours d'écriture.
+  - kind: done
+    content: |-
+      Grosse refonte de <a href="/" target="_blank">la page d'accueil</a> : nouveau header, hero « à la une », système de niveau, onboarding et sidebar.
+  - kind: done
+    content: |-
+      Nouveau design des articles avec un header éditorial et pas mal d'améliorations de confort de lecture.
+  - kind: done
+    content: |-
+      Première version de la refonte éditoriale de <a href="/cours/ci-cd-github-actions" target="_blank">la page de présentation d'un cours</a> (le cours CI/CD GitHub Actions).
+  - kind: done
+    content: |-
+      Petit délire : NX Arcade, une interface de quiz en mode pixel/arcade. À voir sur <a href="/quiz" target="_blank">la page des quiz</a>.
+  - kind: done
+    content: |-
+      Gros travail d'accessibilité : HTML sémantique, attributs ARIA, lien d'évitement (skip link) et textes alternatifs sur les images.
+  - kind: done
+    content: |-
+      J'ai connecté le fil de notes « now » à la base de données — ces petites notes de statut sur ce que je fais en ce moment.
+  - kind: done
+    content: |-
+      Ajout d'un thème d'été avec une jolie icône de plage et des animations de vagues. Il fait beau sur NX :).
+  - kind: done
+    content: |-
+      Centralisation de tout le SEO dans un composant dédié, et correction de quelques balises meta.
+  - kind: fix
+    content: |-
+      Mises à jour de dépendances (@astrojs/db, vitest…).

--- a/src/content/changelog/2026-07.yaml
+++ b/src/content/changelog/2026-07.yaml
@@ -1,0 +1,46 @@
+month: Juillet
+year: 2026
+order: 7
+tasks:
+  - kind: done
+    content: |-
+      J'ai migré tout le changelog vers un nouveau système de fichiers YAML (une <i>content collection</i>). C'est bien plus propre à maintenir — et ça va m'aider à le tenir à jour, promis !
+  - kind: done
+    content: |-
+      Sortie <a href="/articles/cahier-de-vacances-2026" target="_blank">du cahier de vacances du développeur (édition 2026)</a>. De quoi réviser sans se prendre la tête cet été :).
+  - kind: done
+    content: |-
+      Publication de <a href="/articles/ne-plus-se-dedoubler" target="_blank">l'article « Ne plus se dédoubler »</a>, un billet un peu plus perso, orienté réflexion.
+  - kind: in-progress
+    content: |-
+      Je bosse sur un nouvel article de réflexion, « Le DevOps n'est plus l'affaire d'une équipe à part ». Encore en brouillon, je le peaufine avant publication.
+  - kind: done
+    content: |-
+      Ajout de quelques <i>skills</i> Claude pour m'aider à maintenir le site (dont un pour ce changelog, justement).
+  - kind: done
+    content: |-
+      Ajout d'un petit bandeau qui prévient quand le changelog n'a pas été mis à jour depuis un moment. Histoire de me mettre la pression :).
+  - kind: done
+    content: |-
+      Gros travail sur le contenu CI/CD : j'ai publié plusieurs fiches sur GitHub Actions — <a href="/fiches/artefact-github-actions" target="_blank">les artefacts</a>, <a href="/fiches/declencher-workflow-github-actions" target="_blank">déclencher un workflow</a> et <a href="/fiches/deployer-image-docker-github-actions" target="_blank">déployer une image Docker</a>.
+  - kind: in-progress
+    content: |-
+      Je prépare d'autres fiches autour de GitHub Actions (gestion des secrets, réutilisation de workflows, optimisation) ainsi qu'une comparaison GitHub Actions vs GitLab CI. En cours d'écriture.
+  - kind: done
+    content: |-
+      Nouvelle cheatsheet <a href="/fiches/bien-gerer-reseaux-docker" target="_blank">sur la gestion des réseaux Docker</a>.
+  - kind: done
+    content: |-
+      Création de <a href="/methode" target="_blank">la page « Comment je fais apprendre »</a>, qui explique ma méthode pédagogique.
+  - kind: in-progress
+    content: |-
+      Pas mal de travail de SEO pour resserrer le <i>clustering</i> du contenu Docker (liens internes entre cours, fiches et chapitres).
+  - kind: done
+    content: |-
+      Mise en place d'un système de recommandations basé sur la pertinence : en fin d'article, je te propose maintenant des contenus liés.
+  - kind: done
+    content: |-
+      Refonte du menu mobile en overlay plein écran. C'est quand même plus agréable sur téléphone.
+  - kind: fix
+    content: |-
+      Quelques mises à jour de dépendances et de la CI (passage à Node 24).


### PR DESCRIPTION
Reconstitution du changelog de juillet 2026 à partir du `git log` du mois (le fichier `src/content/changelog/2026-07.yaml` n'existait pas encore). Les entrées distinguent le contenu **publié** (`done`) des chantiers encore en **brouillon** (`in-progress`).

Au menu du mois : sortie du cahier de vacances 2026 et de l'article « Ne plus se dédoubler », publication de plusieurs fiches GitHub Actions et d'une cheatsheet réseaux Docker, nouvelle page « Comment je fais apprendre », système de recommandations de contenu, refonte du menu mobile, migration du changelog vers YAML — et en cours : l'article DevOps, la suite du cluster CI/CD et le SEO Docker.

## Things to check before merging:

- **Did you update the changelog?** — Oui, c'est justement l'objet de cette PR : ajout de `src/content/changelog/2026-07.yaml` (14 entrées). `npm run check` et `npm run prettier:check` passent.
- **Did you link GH issues using the Closes directive?** — Pas d'issue associée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8YfQDnWs3DUbjTyZRSu5V

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8YfQDnWs3DUbjTyZRSu5V)_