### PR TITLE
Cadre le cluster « Cloud public » (6 contenus)

### DIFF
--- a/docs/calendrier-editorial.md
+++ b/docs/calendrier-editorial.md
@@ -69,6 +69,22 @@
 - Pourquoi le travail d'informaticien est en train de redevenir passionant ?
 - Personne n'aime l'eau tiède
 
+## Cluster Cloud public — août 2026 à janvier 2027
+
+Cadrage complet : [cluster-cloud-public.md](./cluster-cloud-public.md). Nouvelle
+série `cloud` (rayon « Cloud public » sur `/fiches/`), 4 fiches et 2 articles
+qui se citent en chaîne. Prépare le terrain du cours « Mettez vos applications
+en production ».
+
+| Mois         | Type    | Titre                                                       | Status  |
+| ------------ | ------- | ----------------------------------------------------------- | ------- |
+| Août 2026    | Fiche   | Qu'est-ce que le cloud public ? (pilier)                    | à faire |
+| Septembre    | Fiche   | Cloud public, privé, hybride : quelles différences ?        | à faire |
+| Octobre      | Fiche   | IaaS, PaaS, SaaS : quelles différences et comment choisir ? | à faire |
+| Novembre     | Fiche   | Comment déployer un conteneur Docker dans le cloud ?        | à faire |
+| Décembre     | Article | Le cloud public coûte-t-il vraiment moins cher ?            | à faire |
+| Janvier 2027 | Article | Cloud souverain : de quoi parle-t-on vraiment ?             | à faire |
+
 ## Le Recap
 
 | Mois      | Objectif                          | status     |

--- a/docs/cluster-cloud-public.md
+++ b/docs/cluster-cloud-public.md
@@ -124,18 +124,18 @@ cloud :
 
 Tags partagés, pour faire jouer le scoring inter-clusters : `Cloud` sur les six
 contenus, plus `Docker` / `CI/CD` / `DevOps` / `Souveraineté` selon le contenu.
-Les fiches Docker ont aujourd'hui un `tags:` vide — les remplir au passage est
-ce qui fera remonter le cloud dans leur bloc « À lire ensuite ».
+Douze fiches sur dix-huit n'ont aujourd'hui aucun tag — les compléter est ce qui
+fera remonter le cloud dans leur bloc « À lire ensuite » (voir
+[`dette-editoriale.md`](./dette-editoriale.md)).
 
 ## Points d'attention repérés
 
-- Cinq fiches sont encore dans `src/pages/drafts/` alors que des fiches publiées
-  pointent déjà vers elles : `github-actions-vs-gitlab-ci`,
-  `gerer-secrets-github-actions`, `optimiser-workflows-github-actions`,
-  `reutiliser-workflow-github-actions`, `bien-gerer-secrets-docker`. Ce sont des
-  **404 internes en production**, et le calendrier les marque « DONE ». Hors
-  périmètre de ce cluster, mais à traiter : le cluster cloud va s'appuyer sur ce
-  maillage CI/CD.
+- Deux chantiers préalables sont détaillés dans
+  [`dette-editoriale.md`](./dette-editoriale.md) : quatre liens internes cassés
+  vers des fiches CI/CD restées en brouillon (404 en production), et l'absence
+  de `tags` sur 12 des 18 fiches publiées, qui bride le moteur de
+  recommandations. Hors périmètre de ce cluster, mais le cluster cloud s'appuie
+  précisément sur ces deux mécaniques.
 - Le rayon Cloud public n'apparaîtra sur `/fiches/` qu'à partir de la première
   fiche publiée : ajouter la clé `cloud` en amont ne crée pas de rayon vide.
 

--- a/docs/cluster-cloud-public.md
+++ b/docs/cluster-cloud-public.md
@@ -1,0 +1,179 @@
+# Cluster « Cloud public »
+
+> Cadrage éditorial (pré-rédaction). Objectif : ouvrir une thématique cloud en
+> reprenant la recette qui marche déjà pour Docker et qu'on applique au CI/CD.
+
+## Le constat
+
+- **Docker = le modèle** : 6 fiches publiées (`serie: docker`) qui se citent en
+  chaîne, plus un cours. Maillage interne solide → bon référencement.
+- **CI/CD = en cours** : le cluster est cadré dans
+  [`cluster-cicd-github-actions.md`](./cluster-cicd-github-actions.md), la
+  fiche-pont `deployer-image-docker-github-actions` relie déjà les deux
+  thématiques.
+- **Cloud = zéro contenu**. Aucun contenu ne couvre le vocabulaire de base
+  (IaaS/PaaS/SaaS, régions, facturation à l'usage), alors que c'est la suite
+  logique de la chaîne : on sait construire une image, on sait la pousser depuis
+  GitHub Actions, on ne sait pas encore _où_ elle atterrit.
+
+Le [calendrier éditorial](./calendrier-editorial.md) prévoit par ailleurs un
+cours **« Mettez vos applications en production »** encore à faire. Ce cluster
+lui sert de terrain préparé : quand le cours sortira, six contenus pointeront
+déjà vers lui.
+
+## Le cluster (6 contenus)
+
+Convention : une fiche = un `.md` plat dans `src/pages/fiches/<slug>.md`, front
+matter `layout`, `title`, `description`, `imgAlt`, `imgSrc`, `author`,
+`kind: Fiche technique`, **`serie: cloud`**, `level`, `publishedDate`
+(MM/DD/YYYY), plus un bloc `faq`. Un article = un `.md` dans
+`src/pages/articles/<slug>.md`, `kind: Articles`, `format: reflexion`,
+**`serie: cloud`**, `draft`, `tags`.
+
+Le champ `serie: cloud` est **indispensable** pour apparaître dans le rayon
+Cloud public de `/fiches/` (`src/data/series.ts`) et alimenter le bloc « À lire
+ensuite » (`src/utils/relatedContent/`, poids `serie` = +3, `tag` partagé = +1).
+
+| #   | Type    | Slug                                      | Titre                                                       | level         | Rôle                        |
+| --- | ------- | ----------------------------------------- | ----------------------------------------------------------- | ------------- | --------------------------- |
+| 1   | Fiche   | `comprendre-le-cloud-public`              | Qu'est-ce que le cloud public ?                             | Débutant      | **Pilier** / porte d'entrée |
+| 2   | Fiche   | `difference-cloud-public-prive-hybride`   | Cloud public, privé, hybride : quelles différences ?        | Débutant      | Comparatif (fort volume)    |
+| 3   | Fiche   | `iaas-paas-saas`                          | IaaS, PaaS, SaaS : quelles différences et comment choisir ? | Intermédiaire | Requête exact-match         |
+| 4   | Fiche   | `deployer-conteneur-docker-dans-le-cloud` | Comment déployer un conteneur Docker dans le cloud ?        | Intermédiaire | **Pont Docker ↔ CI/CD**    |
+| 5   | Article | `le-cloud-est-il-vraiment-moins-cher`     | Le cloud public coûte-t-il vraiment moins cher ?            | —             | Réflexion / coûts           |
+| 6   | Article | `cloud-souverain`                         | Cloud souverain : de quoi parle-t-on vraiment ?             | —             | Réflexion / souveraineté    |
+
+### Détail des angles
+
+1. **`comprendre-le-cloud-public`** — Le pilier, celui vers qui tout pointe.
+   Définition (mutualisation, libre-service, élasticité, facturation à l'usage),
+   les cinq caractéristiques du NIST expliquées sans jargon, ce que ça change
+   concrètement pour un dev (plus de serveur à commander, une API à la place),
+   le vocabulaire de base (région, zone de disponibilité, instance, stockage
+   objet) et les limites (coûts variables, dépendance au fournisseur). Miroir
+   structurel de `presentation-registry-docker`.
+
+2. **`difference-cloud-public-prive-hybride`** — Le comparatif d'entrée, calqué
+   sur `difference-docker-compose-swarm`. Tableau des différences (propriété du
+   matériel, mutualisation, coût capex/opex, conformité, élasticité), puis une
+   section « lequel choisir selon ton contexte » (jeune produit / données
+   sensibles / existant on-premise). Y intégrer le multicloud, régulièrement
+   confondu avec l'hybride.
+
+3. **`iaas-paas-saas`** — Le modèle en couches. La métaphore de la pizza (louée,
+   livrée, au restaurant) pour poser l'intuition, puis un tableau « qui gère
+   quoi » ligne par ligne : matériel, réseau, OS, runtime, application, données.
+   Section décision : ce qu'on gagne et ce qu'on perd en montant d'une couche.
+   Le CaaS et le serverless mentionnés en ouverture, vers un contenu futur.
+
+4. **`deployer-conteneur-docker-dans-le-cloud`** — **La fiche-pont**, celle qui
+   porte le maillage. On reprend l'image construite dans le cours Docker et
+   poussée sur un registry par GitHub Actions, et on la fait tourner sur un
+   service managé de conteneurs. Bloc `howTo` en étapes numérotées (comme
+   `prendre-en-main-pico-8`), variables d'environnement, port exposé,
+   healthcheck, coût à l'usage. Elle cite `presentation-registry-docker`,
+   `deployer-image-docker-github-actions` et les deux cours.
+
+5. **`le-cloud-est-il-vraiment-moins-cher`** — Premier article de réflexion. Le
+   paiement à l'usage vu du terrain : ce qui coûte vraiment (frais de sortie de
+   données, stockage oublié, instances sur-dimensionnées), pourquoi la facture
+   surprend, ce que l'auto-hébergement cache comme coûts en face (astreinte,
+   amortissement, remplacement), et le mouvement de repatriement. Registre
+   carnet, pas de conclusion tranchée.
+
+6. **`cloud-souverain`** — Second article de réflexion. Démêler ce que le mot
+   recouvre : souveraineté juridique (Cloud Act, RGPD, extraterritorialité) ≠
+   souveraineté technique (qui opère, qui peut auditer) ≠ label (SecNumCloud).
+   Le paysage français et européen, les offres « de confiance » et leurs zones
+   grises, ce que ça implique concrètement au moment de choisir où déployer. Il
+   s'appuie sur la fiche public/privé/hybride pour le vocabulaire et fait la
+   paire avec l'article coûts : les deux vraies questions qu'on se pose avant de
+   signer.
+
+## Maillage interne (le cœur de la valeur SEO)
+
+Reproduire ce que fait Docker : chaque contenu cite explicitement 1–2 voisins du
+cluster, **en dur dans le corps Markdown**, en plus du scoring automatique.
+Chaîne narrative :
+
+```
+                    comprendre-le-cloud-public (pilier)
+                       │        │            │
+   ┌───────────────────┘        │            └──────────────────┐
+   ▼                            ▼                               ▼
+difference-cloud-*-hybride   iaas-paas-saas          le-cloud-est-il-moins-cher
+   │      │                     │                               ▲
+   │      └──► cloud-souverain ─┼───────────────────────────────┤
+   │                            │      (les deux articles se citent)
+   └────────────┬───────────────┘                               │
+                ▼                                               │
+   deployer-conteneur-docker-dans-le-cloud ─────────────────────┘
+                │
+                ├─► /fiches/presentation-registry-docker         (cluster Docker)
+                ├─► /fiches/deployer-image-docker-github-actions (cluster CI/CD)
+                └─► /cours/docker-et-docker-compose/ + /cours/ci-cd-github-actions/
+```
+
+Rétro-liens à poser depuis l'existant, aujourd'hui sans aucune porte vers le
+cloud :
+
+- `src/pages/fiches/deployer-image-docker-github-actions.md` → la fiche-pont
+  (suite logique : l'image est poussée, reste à la faire tourner) ;
+- `src/pages/fiches/decouvrir-docker-swarm.md` → la fiche-pont (l'alternative
+  managée à l'orchestration maison).
+
+Tags partagés, pour faire jouer le scoring inter-clusters : `Cloud` sur les six
+contenus, plus `Docker` / `CI/CD` / `DevOps` / `Souveraineté` selon le contenu.
+Les fiches Docker ont aujourd'hui un `tags:` vide — les remplir au passage est
+ce qui fera remonter le cloud dans leur bloc « À lire ensuite ».
+
+## Points d'attention repérés
+
+- Cinq fiches sont encore dans `src/pages/drafts/` alors que des fiches publiées
+  pointent déjà vers elles : `github-actions-vs-gitlab-ci`,
+  `gerer-secrets-github-actions`, `optimiser-workflows-github-actions`,
+  `reutiliser-workflow-github-actions`, `bien-gerer-secrets-docker`. Ce sont des
+  **404 internes en production**, et le calendrier les marque « DONE ». Hors
+  périmètre de ce cluster, mais à traiter : le cluster cloud va s'appuyer sur ce
+  maillage CI/CD.
+- Le rayon Cloud public n'apparaîtra sur `/fiches/` qu'à partir de la première
+  fiche publiée : ajouter la clé `cloud` en amont ne crée pas de rayon vide.
+
+## Fichiers concernés (au moment de la rédaction)
+
+- **Créés** : 4 fiches `src/pages/fiches/<slug>.md` et 2 articles
+  `src/pages/articles/<slug>.md`.
+- **Édité** : `src/data/series.ts` (clé `cloud`, faite en amont).
+- **Édités** : `src/pages/fiches/deployer-image-docker-github-actions.md` et
+  `src/pages/fiches/decouvrir-docker-swarm.md` (rétro-liens), `tags` des fiches
+  Docker.
+- **Images** : une par contenu, source `raw/cheatsheets/<slug>.png` ou
+  `raw/articles/<slug>.png` → générée en `.webp` via `npm run optimize-images`,
+  référencée `imgSrc: /images/cheatsheets/<slug>.webp` (ou `/images/articles/`).
+- **Calendrier** : mettre à jour `docs/calendrier-editorial.md`.
+- **Changelog** : proposer une entrée dans
+  `src/content/changelog/<AAAA-MM>.yaml` à chaque publication.
+- **Optionnel** : quiz `public/quiz/<slug>.json` et entrées dans
+  `src/data/quiz.ts` avec un nouveau `topic: "Cloud"`.
+
+## Vérification (au moment de la rédaction)
+
+- `npm run build` (= `astro check && astro build --remote`) passe sans erreur.
+- Chaque nouvelle fiche apparaît dans le rayon **Cloud public** de `/fiches/`.
+- Le bloc « À lire ensuite » de chaque contenu affiche bien ses voisins cloud.
+- Liens internes en dur valides (pas de 404 vers un slug resté en draft).
+- `npm run prettier:check` passe.
+- Ton NX (tutoiement, « on »), exemples testables, typo française.
+
+## Séquençage suggéré
+
+1. `comprendre-le-cloud-public` — le pilier d'abord, tout pointe vers lui.
+2. `difference-cloud-public-prive-hybride` — la porte d'entrée SEO.
+3. `iaas-paas-saas`.
+4. `deployer-conteneur-docker-dans-le-cloud` — le pont, une fois les bases
+   posées.
+5. `le-cloud-est-il-vraiment-moins-cher` — la question du coût.
+6. `cloud-souverain` — la question du « où et chez qui ».
+
+Puis pose du maillage croisé, rétro-liens depuis Docker et CI/CD, et mise à jour
+du calendrier.

--- a/docs/dette-editoriale.md
+++ b/docs/dette-editoriale.md
@@ -1,0 +1,101 @@
+# Dette éditoriale à traiter
+
+> Constats relevés en cadrant le
+> [cluster Cloud public](./cluster-cloud-public.md). Deux chantiers courts, à
+> traiter **avant** d'ouvrir la thématique cloud : le cluster cloud va s'appuyer
+> sur le maillage CI/CD et sur le moteur de recommandations, or les deux sont
+> aujourd'hui abîmés.
+
+## 1. Liens internes cassés vers des fiches restées en brouillon
+
+**Priorité : haute.** Ce sont des 404 en production, sur des fiches publiées et
+indexées.
+
+Quatre liens en dur pointent vers trois slugs qui vivent encore dans
+`src/pages/drafts/`. Les brouillons sont routés en `/drafts/<slug>` (exclus du
+sitemap par `astro.config.ts`), donc les URLs `/fiches/<slug>` citées n'existent
+pas.
+
+| Fichier source                                             | Ligne    | Lien mort                              |
+| ---------------------------------------------------------- | -------- | -------------------------------------- |
+| `src/pages/fiches/declencher-workflow-github-actions.md`   | 356      | `/fiches/github-actions-vs-gitlab-ci`  |
+| `src/pages/fiches/deployer-image-docker-github-actions.md` | 84 · 267 | `/fiches/gerer-secrets-github-actions` |
+| `src/pages/fiches/decouvrir-docker-swarm.md`               | 231      | `/fiches/bien-gerer-secrets-docker/`   |
+
+Cinq fiches attendent dans `src/pages/drafts/` (les trois ci-dessus, plus
+`optimiser-workflows-github-actions` et `reutiliser-workflow-github-actions`,
+qui ne sont cités nulle part). Elles sont rédigées, front matter complet. Le
+[calendrier](./calendrier-editorial.md) marque d'ailleurs « Comment optimiser
+vos workflows GitHub Actions ? » comme **DONE** alors que la fiche n'est pas
+publiée.
+
+**Ce qu'il manque pour les publier : les visuels, essentiellement.** Toutes
+pointent vers un `imgSrc` dans `/images/cheatsheets/`, mais seul
+`bien-gerer-secrets-docker` a le sien (`secrets-docker.webp`). Les quatre autres
+référencent un `<slug>.webp` qui n'existe pas : il faut produire le visuel pixel
+art, le déposer en `raw/cheatsheets/<slug>.png` et lancer
+`npm run optimize-images`.
+
+Plus, pour chacune : vérifier `serie: cicd` (indispensable pour le rayon CI/CD),
+rafraîchir `publishedDate`, `git mv` vers `src/pages/fiches/`.
+
+**Deux issues possibles**, la première étant nettement préférable :
+
+1. **Publier** les brouillons (le contenu est écrit, il ne manque que les
+   visuels et un passage de relecture) — ça ferme les 404 et ça termine le
+   cluster CI/CD cadré dans
+   [`cluster-cicd-github-actions.md`](./cluster-cicd-github-actions.md).
+2. À défaut, **retirer les quatre liens** des fiches publiées, en attendant.
+
+Ne rien faire est la seule option à écarter : les trois fiches concernées sont
+parmi les plus visitées du site.
+
+## 2. Tags absents sur la majorité des fiches
+
+**Priorité : moyenne.** Pas de casse visible, mais le bloc « À lire ensuite »
+tourne au ralenti.
+
+`src/utils/relatedContent/` score les contenus liés avec `serie` = +3 et chaque
+`tag` partagé = +1. Sans tags, seule la série joue : à l'intérieur d'un rayon,
+le classement retombe sur l'ordre chronologique, et le rapprochement entre deux
+séries (Docker ↔ CI/CD ↔ Cloud) ne peut pas se faire du tout.
+
+État actuel des 18 fiches publiées :
+
+- **6 taguées** : `bien-faire-multi-stage-build`, `bien-gerer-reseaux-docker`,
+  `decouvrir-docker-swarm`, `difference-docker-compose-swarm`,
+  `optimisation-images-docker`, `presentation-registry-docker` ;
+- **1 avec un `tags:` vide** : `deployer-image-docker-github-actions` ;
+- **11 sans le champ** : les deux autres fiches CI/CD, les trois fiches
+  JavaScript, la fiche CSS, les deux fiches game dev, les deux fiches outils, et
+  `bien-utiliser-volumes-docker`.
+
+Le vocabulaire employé aujourd'hui est mince et implicite : `Production` (×3),
+`Image` (×3), `Orchestration` (×2), `Réseau`, `Registry`, `Compose`. Il tient
+debout à l'intérieur du rayon Docker, pas au-delà.
+
+**Ce qu'il faut faire**, dans cet ordre :
+
+1. Arrêter un vocabulaire de tags avant de le généraliser — sinon on aura autant
+   de tags que de fiches et le poids de +1 ne voudra plus rien dire. Piste : des
+   tags transverses (`Production`, `Sécurité`, `Performance`, `Débutant`) en
+   plus des tags d'outil (`Docker`, `GitHub Actions`, `Cloud`).
+2. Compléter les 12 fiches concernées, en commençant par les clusters Docker et
+   CI/CD, ceux sur lesquels le cluster cloud viendra s'accrocher.
+
+## Vu au passage
+
+Moins urgent, noté pour ne pas le reperdre : `quizUrl` de la landing du cours
+CI/CD (`src/pages/cours/ci-cd-github-actions/index.astro`, ligne 80) pointe vers
+`/quiz/quiz-niveau-docker`, le quiz de niveau Docker. Il n'existe pas encore de
+quiz de niveau CI/CD dans `src/data/quiz.ts` — d'où le repli, probablement
+volontaire. À reprendre quand le cluster CI/CD sera complet.
+
+## Vérification, une fois traité
+
+- Plus aucun lien `/fiches/<slug>` ne pointe vers un fichier de
+  `src/pages/drafts/`.
+- Les cinq fiches apparaissent dans le rayon **CI/CD** de `/fiches/`.
+- Le bloc « À lire ensuite » d'une fiche Docker propose au moins une fiche
+  CI/CD, et inversement.
+- `npm run build` et `npm run prettier:check` passent.

--- a/src/data/series.ts
+++ b/src/data/series.ts
@@ -21,6 +21,11 @@ export const SERIES: Record<string, Serie> = {
     label: "CI/CD",
     blurb: "Automatiser tests et mises en production avec les GitHub Actions.",
   },
+  cloud: {
+    label: "Cloud public",
+    blurb:
+      "Comprendre le cloud avant d'y déployer : modèles de service, public ou privé, coûts réels.",
+  },
   js: {
     label: "JavaScript",
     blurb:


### PR DESCRIPTION
Pose les fondations du cluster cloud, sur le modèle du cadrage CI/CD :

- docs/cluster-cloud-public.md : le brief de cluster (4 fiches + 2 articles,
  angles, maillage interne, rétro-liens depuis Docker et CI/CD, séquençage) ;
- src/data/series.ts : nouvelle série `cloud` (rayon « Cloud public » sur
  /fiches/), rangée après CI/CD pour la progression conteneur → pipeline →
  production ;
- docs/calendrier-editorial.md : les six contenus au planning, d'août 2026 à
  janvier 2027.

Rien de visible en ligne pour l'instant : le rayon n'apparaît qu'à partir de la
première fiche publiée.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RExMmKGdwmmyzPQ623Sp9Z