### PR TITLE
Ajoute la table RecapLink pour capter les liens du récap

### DIFF
--- a/db/config.ts
+++ b/db/config.ts
@@ -1,4 +1,4 @@
-import { defineDb, defineTable, column } from "astro:db";
+import { defineDb, defineTable, column, NOW } from "astro:db";
 
 const NewsFeed = defineTable({
   columns: {
@@ -25,10 +25,23 @@ const NowNoteFeed = defineTable({
   },
 });
 
+const RecapLink = defineTable({
+  columns: {
+    id: column.number({
+      primaryKey: true,
+      autoIncrement: true,
+    }),
+    addedAt: column.date({ default: NOW }),
+    description: column.text(),
+    url: column.text(),
+  },
+});
+
 // https://astro.build/db/config
 export default defineDb({
   tables: {
     NewsFeed,
     NowNoteFeed,
+    RecapLink,
   },
 });

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,4 +1,4 @@
-import { db, NewsFeed, NowNoteFeed } from "astro:db";
+import { db, NewsFeed, NowNoteFeed, RecapLink } from "astro:db";
 
 // https://astro.build/db/seed
 export default async function seed() {
@@ -48,6 +48,23 @@ export default async function seed() {
       slug: "une-faille-critique-corrigée-dans",
       title: "Une faille critique corrigée dans OpenSSL 3.2.1",
       url: "https://openssl.org/news/une-faille-critique-corrigée-dans",
+    },
+  ]);
+
+  await db.insert(RecapLink).values([
+    {
+      id: 1,
+      addedAt: new Date("2026-07-03"),
+      description:
+        "Un retour d'expérience sur la migration d'un bot Discord vers un serveur MCP, avec les pièges d'authentification.",
+      url: "https://example.com/discord-vers-mcp",
+    },
+    {
+      id: 2,
+      addedAt: new Date("2026-07-18"),
+      description:
+        "Une analyse des choix de conception derrière PICO-8 et de ce que les contraintes apportent à la création.",
+      url: "https://example.com/pico-8-contraintes",
     },
   ]);
 }

--- a/src/content/changelog/2026-07.yaml
+++ b/src/content/changelog/2026-07.yaml
@@ -2,6 +2,9 @@ month: Juillet
 year: 2026
 order: 7
 tasks:
+  - kind: in-progress
+    content: |-
+      J'ai ajouté une table en base pour ranger au fil de l'eau les liens que je trouve intéressants. L'idée : en fin de mois, interroger la base pour monter <a href="/articles/le-recap" target="_blank">le récap</a> au lieu de fouiller mes notes. Reste à brancher mon serveur MCP dessus.
   - kind: done
     content: |-
       Nouvelle fiche technique dédiée <a href="/fiches/decouvrir-docker-swarm" target="_blank">aux secrets Docker</a>.


### PR DESCRIPTION
Une boîte de capture en base pour les liens intéressants trouvés au fil
de l'eau, à interroger en fin de mois via le MCP pour monter le récap.

- `RecapLink` : id, addedAt (default NOW), description, url
- deux lignes de seed pour pouvoir requêter en local
- entrée de changelog pour juillet 2026

La table reste vide tant que les outils d'écriture et de lecture ne sont
pas ajoutés côté serveur MCP, qui vit dans un autre dépôt.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018deYL6ZyPAbBbUh3oqL3Yp