### PR TITLE
Écrit les deux premières fiches du cluster « Cloud public » (en brouillon)

### DIFF
--- a/docs/calendrier-editorial.md
+++ b/docs/calendrier-editorial.md
@@ -69,21 +69,21 @@
 - Pourquoi le travail d'informaticien est en train de redevenir passionant ?
 - Personne n'aime l'eau tiède
 
-## Cluster Cloud public — août 2026 à janvier 2027
+## Cluster Cloud public — juillet 2026 à janvier 2027
 
 Cadrage complet : [cluster-cloud-public.md](./cluster-cloud-public.md). Nouvelle
 série `cloud` (rayon « Cloud public » sur `/fiches/`), 4 fiches et 2 articles
 qui se citent en chaîne. Prépare le terrain du cours « Mettez vos applications
 en production ».
 
-| Mois         | Type    | Titre                                                       | Status  |
-| ------------ | ------- | ----------------------------------------------------------- | ------- |
-| Août 2026    | Fiche   | Qu'est-ce que le cloud public ? (pilier)                    | à faire |
-| Septembre    | Fiche   | Cloud public, privé, hybride : quelles différences ?        | à faire |
-| Octobre      | Fiche   | IaaS, PaaS, SaaS : quelles différences et comment choisir ? | à faire |
-| Novembre     | Fiche   | Comment déployer un conteneur Docker dans le cloud ?        | à faire |
-| Décembre     | Article | Le cloud public coûte-t-il vraiment moins cher ?            | à faire |
-| Janvier 2027 | Article | Cloud souverain : de quoi parle-t-on vraiment ?             | à faire |
+| Mois         | Type    | Titre                                                       | Status    |
+| ------------ | ------- | ----------------------------------------------------------- | --------- |
+| Juillet 2026 | Fiche   | Qu'est-ce que le cloud public ? (pilier)                    | brouillon |
+| Juillet 2026 | Fiche   | Cloud public, privé, hybride : quelles différences ?        | brouillon |
+| Octobre      | Fiche   | IaaS, PaaS, SaaS : quelles différences et comment choisir ? | à faire   |
+| Novembre     | Fiche   | Comment déployer un conteneur Docker dans le cloud ?        | à faire   |
+| Décembre     | Article | Le cloud public coûte-t-il vraiment moins cher ?            | à faire   |
+| Janvier 2027 | Article | Cloud souverain : de quoi parle-t-on vraiment ?             | à faire   |
 
 ## Le Recap
 

--- a/docs/cluster-cloud-public.md
+++ b/docs/cluster-cloud-public.md
@@ -163,7 +163,10 @@ fera remonter le cloud dans leur bloc « À lire ensuite » (voir
 - Le bloc « À lire ensuite » de chaque contenu affiche bien ses voisins cloud.
 - Liens internes en dur valides (pas de 404 vers un slug resté en draft).
 - `npm run prettier:check` passe.
-- Ton NX (tutoiement, « on »), exemples testables, typo française.
+- Ton NX (vouvoiement, « on » pour la progression, « je » pour l'avis), exemples
+  testables, typo française. Les 19 fiches publiées vouvoient sans exception :
+  ce point du brief disait « tutoiement », il a été corrigé en rédigeant les
+  deux premières fiches.
 
 ## Séquençage suggéré
 

--- a/src/content/changelog/2026-07.yaml
+++ b/src/content/changelog/2026-07.yaml
@@ -5,6 +5,9 @@ tasks:
   - kind: in-progress
     content: |-
       J'ai ajouté une table en base pour ranger au fil de l'eau les liens que je trouve intéressants. L'idée : en fin de mois, interroger la base pour monter <a href="/articles/le-recap" target="_blank">le récap</a> au lieu de fouiller mes notes. Reste à brancher mon serveur MCP dessus.
+  - kind: in-progress
+    content: |-
+      Le cluster Cloud public est en chantier. Les deux premières fiches sont écrites — ce qu'est le cloud public, et la différence entre public, privé et hybride — elles attendent leurs visuels avant publication.
   - kind: done
     content: |-
       Nouvelle fiche technique dédiée <a href="/fiches/decouvrir-docker-swarm" target="_blank">aux secrets Docker</a>.

--- a/src/pages/drafts/comprendre-le-cloud-public.md
+++ b/src/pages/drafts/comprendre-le-cloud-public.md
@@ -1,0 +1,297 @@
+---
+layout: ../../layouts/CheatSheetsLayout.astro
+
+title: "Qu'est-ce que le cloud public ?"
+description:
+  "Comprenez ce qu'est vraiment le cloud public : mutualisation, libre-service,
+  élasticité et facturation à l'usage. Les cinq caractéristiques du NIST sans le
+  jargon, le vocabulaire de base (région, zone de disponibilité, instance,
+  stockage objet) et les limites à connaître avant de déployer."
+
+imgAlt:
+  Un immense entrepôt de serveurs vu de l'intérieur, avec un petit conteneur
+  posé sur un chariot, pixel art
+imgSrc: /images/cheatsheets/comprendre-le-cloud-public.webp
+
+author: Thomas
+kind: Fiche technique
+serie: cloud
+tags:
+  - Cloud
+  - Production
+level: Débutant
+publishedDate: 07/30/2026
+
+faq:
+  - question: Qu'est-ce que le cloud public ?
+    answer:
+      "Le cloud public, c'est de la puissance de calcul, du stockage et des
+      services réseau loués à la demande chez un fournisseur, sur une
+      infrastructure mutualisée entre tous ses clients. Vous ne possédez aucune
+      machine : vous payez ce que vous consommez, à la seconde ou au gigaoctet."
+  - question:
+      Quelle est la différence entre le cloud public et un hébergeur classique ?
+    answer:
+      "L'hébergeur classique vous loue une machine pour une durée fixe, souvent
+      au mois, et vous la livrez en quelques heures. Le cloud public vous laisse
+      créer et détruire des ressources vous-même, par API, en quelques secondes,
+      et ne facture que le temps réellement consommé."
+  - question: Le cloud public est-il moins cher qu'un serveur dédié ?
+    answer:
+      "Pas systématiquement. Le cloud est très avantageux pour une charge
+      variable ou imprévisible, parce que vous ne payez rien quand vous ne
+      consommez rien. Sur une charge stable et connue 24 h/24, un serveur dédié
+      revient souvent moins cher."
+---
+
+Après plusieurs mois passés sur Docker puis sur les GitHub Actions, on ouvre
+aujourd'hui une nouvelle série de fiches techniques sur NX : le cloud public.
+
+Faisons d'abord le point sur le chemin parcouru. Vous savez
+[construire une image Docker](/cours/docker-et-docker-compose/), vous savez
+[la pousser sur un registry](/fiches/presentation-registry-docker/), et vous
+savez même
+[le faire automatiquement depuis GitHub Actions](/fiches/deployer-image-docker-github-actions/).
+Il reste pourtant une question, et elle est de taille : **cette image, elle
+tourne où ?**
+
+Jusqu'ici, la réponse implicite était « sur un serveur ». Sauf que ce serveur,
+quelqu'un a bien dû le commander, le brancher, l'installer, le mettre à jour et
+le remplacer quand il a lâché. Le cloud public, c'est exactement ce qui a fait
+disparaître cette étape du quotidien de la plupart des développeurs.
+
+Dans cette fiche, on pose le décor : ce qu'est vraiment le cloud public, les
+cinq caractéristiques qui le définissent, le vocabulaire que vous allez croiser
+partout, et les limites qu'on ne découvre qu'une fois dedans. Pas de console de
+fournisseur ni de tutoriel pas à pas ici — ça viendra plus tard dans la série.
+
+---
+
+## C'est quoi le cloud public, concrètement ?
+
+Le cloud public, c'est de la **puissance de calcul, du stockage et du réseau
+loués à la demande** chez un fournisseur, sur une infrastructure qu'il partage
+entre tous ses clients.
+
+<br>
+
+Quatre idées suffisent à en faire le tour :
+
+- **la mutualisation** : les mêmes machines physiques servent à des milliers de
+  clients, chacun isolé des autres. C'est ce partage qui permet au fournisseur
+  d'amortir un parc que personne ne pourrait s'offrir seul ;
+- **le libre-service** : vous créez et détruisez vos ressources vous-même, sans
+  demander l'autorisation à qui que ce soit, sans bon de commande et sans délai
+  de livraison ;
+- **l'élasticité** : vous montez de deux à vingt serveurs le temps d'un pic de
+  trafic, puis vous redescendez. Sans rien jeter, puisque vous ne possédez
+  rien ;
+- **la facturation à l'usage** : vous payez ce que vous consommez, souvent à la
+  seconde de calcul et au gigaoctet stocké.
+
+<br>
+
+Le mot « public » ne veut pas dire que vos données sont visibles de tous. Il
+qualifie l'infrastructure, pas vos données : elle est **ouverte à tout client
+qui la loue**, par opposition à un parc de machines réservé à une seule
+organisation. On reviendra en détail sur cette distinction, c'est le sujet de
+[la fiche suivante](/drafts/difference-cloud-public-prive-hybride).
+
+<br>
+
+Les noms que vous connaissez déjà : Amazon Web Services, Microsoft Azure et
+Google Cloud pour les trois plus gros, OVHcloud, Scaleway, Clever Cloud ou
+Hetzner du côté européen. Tous vendent la même chose sur le principe, avec des
+catalogues et des tarifs très différents.
+
+---
+
+## Les cinq caractéristiques du NIST, sans le jargon
+
+Il existe une définition de référence du _cloud computing_, publiée en 2011 par
+le NIST, l'institut de normalisation américain. Elle tient en cinq
+caractéristiques et, quinze ans plus tard, elle décrit toujours très bien ce
+qu'on achète.
+
+<br>
+
+Les voici, traduites en français courant :
+
+1. **Le libre-service à la demande** — vous provisionnez une machine ou du
+   stockage tout seul, en quelques clics ou en une commande. Personne à
+   appeler ;
+2. **L'accès par le réseau** — tout est joignable à distance, par des protocoles
+   standards, depuis n'importe quel poste ou n'importe quel outil ;
+3. **La mutualisation des ressources** — le fournisseur sert plusieurs clients
+   avec le même matériel, en réattribuant dynamiquement la capacité ;
+4. **L'élasticité rapide** — la capacité s'ajuste vite, parfois automatiquement,
+   et vous donne l'illusion de ressources infinies ;
+5. **Le service mesuré** — tout est compté et facturé à l'usage, et vous pouvez
+   consulter cette mesure.
+
+<br>
+
+Retenez surtout la cinquième, c'est la plus structurante. **Si ce n'est pas
+mesuré et facturé à l'usage, ce n'est pas du cloud** : c'est de la location de
+serveur avec une jolie interface. Le test est assez fiable pour trier les offres
+que vous croiserez.
+
+---
+
+## Ce que ça change pour vous, développeur
+
+Dans un modèle classique, obtenir un serveur passait par une demande, un budget,
+un bon de commande, une livraison, un montage en rack et une installation. On
+comptait en semaines, parfois en mois. Et comme la commande engageait pour trois
+ans, on prenait large « au cas où ».
+
+<br>
+
+Dans le cloud public, l'infrastructure devient **une API**. La même que celle
+qui se cache derrière la console web du fournisseur, et derrière sa CLI :
+
+```bash
+# La commande exacte dépend du fournisseur, mais la logique est toujours la même
+cloud compute instance create mon-api \
+  --type=2vcpu-4go \
+  --region=europe-west-paris
+```
+
+<br>
+
+Trois conséquences très concrètes pour votre travail quotidien :
+
+- **l'infrastructure se code et se versionne**. Puisque tout passe par une API,
+  on décrit son infrastructure dans des fichiers, on les met dans Git et on les
+  rejoue à l'identique. C'est ce qu'on appelle l'*infrastructure as code* ;
+- **l'environnement de test redevient abordable**. Monter une copie complète de
+  la production pour deux heures ne coûte que deux heures ;
+- **le dimensionnement n'est plus un pari**. On démarre petit, on observe, on
+  ajuste. Se tromper ne coûte plus trois ans d'amortissement.
+
+<br>
+
+C'est aussi ce qui explique que la frontière entre développement et exploitation
+se soit brouillée. Quand créer un serveur est devenu un appel d'API, la personne
+qui écrit le code s'est retrouvée en situation de le déployer elle-même.
+
+---
+
+## Le vocabulaire de base
+
+Quatre termes reviennent dans toutes les documentations, quel que soit le
+fournisseur. Les connaître vous évitera de vous perdre dès la première page.
+
+| Terme                     | Ce que c'est                                                                | Pourquoi ça compte                                                       |
+| ------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **Région**                | Une zone géographique où le fournisseur possède des centres de données      | Détermine où vos données résident et la latence pour vos clients         |
+| **Zone de disponibilité** | Un centre de données isolé (électricité, réseau) à l'intérieur d'une région | Répartir votre application pour survivre à la panne d'un site            |
+| **Instance**              | Une machine virtuelle louée, dimensionnée en vCPU et en Go de mémoire       | C'est là que tourne votre conteneur, votre API, votre base               |
+| **Stockage objet**        | Un espace où l'on dépose des fichiers, adressés chacun par une URL          | Images, sauvegardes, artefacts de build : tout ce qui n'est pas une base |
+
+<br>
+
+Deux pièges classiques sur ces notions.
+
+<br>
+
+Le premier : **région et zone de disponibilité ne se valent pas**. Déployer deux
+instances dans la même zone ne vous protège de rien — un incendie ou une coupure
+électrique emporte les deux. C'est en répartissant sur plusieurs zones d'une
+même région qu'on gagne en résilience.
+
+<br>
+
+Le second : **le stockage objet n'est pas un disque**. On n'y modifie pas un
+fichier en place et on n'y monte pas un système de fichiers comme
+[avec un volume Docker](/fiches/bien-utiliser-volumes-docker/). On dépose un
+objet, on le récupère, on le remplace entièrement. C'est parfait pour des
+fichiers immuables, très mauvais pour une base de données.
+
+---
+
+## Les limites qu'on découvre à l'usage
+
+Le cloud public a des contreparties réelles, et il vaut mieux les connaître
+avant de signer qu'après.
+
+<br>
+
+**La facture est variable, donc difficile à prévoir.** C'est le revers exact de
+l'élasticité : payer à l'usage veut aussi dire payer un usage qui dérape. Une
+instance oubliée un week-end, un bucket de sauvegardes qui grossit sans
+surveillance, un pic de trafic inattendu, et le montant du mois n'a plus rien à
+voir avec l'estimation. On consacrera un contenu entier à cette question, elle
+le mérite.
+
+<br>
+
+**La sortie des données se paie.** Faire entrer des données chez un fournisseur
+est presque toujours gratuit. Les faire sortir, non. C'est ce qu'on appelle les
+frais d'_egress_, et c'est ce qui rend un déménagement bien plus coûteux qu'on
+ne l'imagine.
+
+<br>
+
+**La dépendance au fournisseur est progressive.** Une machine virtuelle et un
+disque se déplacent sans trop de peine. Une application construite sur la file
+de messages maison, la base propriétaire et le service d'authentification d'un
+fournisseur, beaucoup moins. C'est le _vendor lock-in_, et il s'installe
+rarement d'un coup : il s'accumule service après service.
+
+<br>
+
+**Vous héritez des pannes du fournisseur.** Sa disponibilité devient la vôtre,
+et vous n'avez aucun levier pendant l'incident. C'est en général bien meilleur
+que ce qu'une petite équipe obtiendrait seule — mais vous ne pouvez qu'attendre.
+
+---
+
+## Astuce bonus - Lisez la grille tarifaire avant de déployer
+
+Le réflexe qui évite les plus mauvaises surprises tient en une phrase : **ouvrez
+la page des tarifs avant la documentation technique**.
+
+<br>
+
+Trois points à y chercher systématiquement :
+
+- **le prix de sortie des données**, souvent relégué en bas de page alors qu'il
+  décide de votre facture si vous servez des fichiers volumineux ;
+- **ce qui reste facturé à l'arrêt**. Une instance éteinte ne coûte plus de
+  calcul, mais son disque, son adresse IP réservée et ses sauvegardes, si ;
+- **le palier gratuit et sa date de fin**. Beaucoup d'offres d'essai basculent
+  au tarif plein sans prévenir au bout de douze mois.
+
+<br>
+
+Et dans la foulée : **posez une alerte de budget dès la création du compte**.
+Tous les fournisseurs en proposent, ça prend deux minutes, et c'est le seul
+garde-fou qui vous préviendra qu'un service tourne pour rien.
+
+<hr>
+
+Et voilà, vous avez le décor ! Si vous ne deviez retenir qu'une chose : **le
+cloud public, c'est de l'infrastructure mutualisée, pilotée par API et facturée
+à l'usage** — le reste en découle, l'élasticité comme l'imprévisibilité de la
+facture.
+
+Dans la prochaine fiche, on lève la confusion la plus fréquente du domaine :
+[cloud public, privé, hybride, quelles différences](/drafts/difference-cloud-public-prive-hybride)
+et, tant qu'à faire, ce que vient faire le multicloud là-dedans. À très vite 😉.
+
+D'ici là, je vous invite :
+
+- [à relire la fiche sur les registries Docker](/fiches/presentation-registry-docker/),
+  puisque c'est de là que partira l'image qu'on déploiera plus tard dans cette
+  série ;
+- [à (re)commencer le cours sur Docker et Docker Compose](/cours/docker-et-docker-compose/)
+  si les conteneurs sont encore flous.
+
+## Ressources
+
+- [The NIST Definition of Cloud Computing (SP 800-145)](https://csrc.nist.gov/pubs/sp/800/145/final)
+- [Régions et zones de disponibilité (AWS)](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
+- [Geography and regions (Google Cloud)](https://cloud.google.com/docs/geography-and-regions)
+- [Le glossaire Cloud Native de la CNCF, en français](https://glossary.cncf.io/fr/)
+- [Recommandations de la CNIL sur l'informatique en nuage](https://www.cnil.fr/fr/definition/informatique-en-nuage-cloud-computing)

--- a/src/pages/drafts/difference-cloud-public-prive-hybride.md
+++ b/src/pages/drafts/difference-cloud-public-prive-hybride.md
@@ -1,0 +1,327 @@
+---
+layout: ../../layouts/CheatSheetsLayout.astro
+
+title: "Cloud public, privé, hybride : quelles différences ?"
+description:
+  "Comprenez enfin la différence entre cloud public, cloud privé et cloud
+  hybride. Qui possède le matériel, qui paie quoi, ce que chaque modèle apporte
+  en conformité et en élasticité — et pourquoi le multicloud n'est pas
+  l'hybride."
+
+imgAlt:
+  Trois bâtiments côte à côte, un immeuble partagé, une maison individuelle et
+  une passerelle entre les deux, pixel art
+imgSrc: /images/cheatsheets/difference-cloud-public-prive-hybride.webp
+
+author: Thomas
+kind: Fiche technique
+serie: cloud
+tags:
+  - Cloud
+  - Production
+level: Débutant
+publishedDate: 07/31/2026
+
+faq:
+  - question: Quelle est la différence entre cloud public et cloud privé ?
+    answer:
+      "Dans le cloud public, l'infrastructure appartient à un fournisseur et
+      elle est mutualisée entre tous ses clients. Dans le cloud privé, elle est
+      dédiée à une seule organisation, qu'elle soit installée dans ses locaux ou
+      hébergée ailleurs pour son compte exclusif."
+  - question: Le cloud hybride, c'est quoi exactement ?
+    answer:
+      "C'est un système d'information qui combine cloud public et cloud privé
+      (ou serveurs internes), reliés entre eux pour que les applications et les
+      données puissent circuler. On garde le sensible d'un côté, on met
+      l'élastique de l'autre."
+  - question: Le multicloud et le cloud hybride, est-ce la même chose ?
+    answer:
+      "Non. Le multicloud, c'est utiliser plusieurs fournisseurs publics en même
+      temps. L'hybride, c'est mélanger du public et du privé. On peut être
+      multicloud sans être hybride, et l'inverse."
+---
+
+Dans [la fiche précédente](/drafts/comprendre-le-cloud-public), on a posé ce
+qu'était le cloud public : de l'infrastructure mutualisée, pilotée par API et
+facturée à l'usage. Le mot « public » y faisait déjà un peu de bruit, et c'est
+normal.
+
+Parce que dès qu'on ouvre une documentation ou qu'on écoute une présentation
+commerciale, trois termes arrivent ensemble, souvent dans la même phrase :
+**cloud public, cloud privé, cloud hybride**. Et régulièrement un quatrième
+s'invite, le **multicloud**, présenté comme un synonyme de l'hybride alors qu'il
+n'a rien à voir.
+
+Trois modèles, un intrus, et beaucoup de conversations qui partent de travers
+parce que deux personnes n'emploient pas le même mot pour la même chose.
+
+Dans cette fiche, on démêle tout ça. Vous allez voir que la question de départ
+est beaucoup plus simple qu'il n'y paraît : **à qui appartient le matériel, et
+avec qui le partagez-vous ?**
+
+---
+
+## Pourquoi on les confond aussi souvent ?
+
+Ces modèles se confondent pour une bonne raison : **de l'extérieur, ils se
+ressemblent tous**. Dans les trois cas, vous obtenez des machines à la demande,
+vous les pilotez par une API et vous voyez une console web.
+
+<br>
+
+Ce qui les sépare n'est pas visible depuis votre terminal. C'est un ensemble de
+questions de propriété et de partage :
+
+- **qui possède le matériel** — vous, votre entreprise, ou un fournisseur ?
+- **avec qui le partagez-vous** — personne, ou tous les autres clients ?
+- **qui paie quoi, et quand** — un investissement d'un coup, ou une facture
+  mensuelle variable ?
+
+<br>
+
+Une fois ces trois questions posées, la classification devient limpide. On
+déroule les trois modèles dans l'ordre.
+
+---
+
+## Le cloud public = mutualisé, chez un fournisseur
+
+C'est le modèle qu'on a détaillé dans la fiche précédente. Le fournisseur
+possède les centres de données, les machines et le réseau, et il loue de la
+capacité à qui la demande. **Votre application tourne sur du matériel partagé
+avec d'autres clients**, chacun isolé des autres par la virtualisation.
+
+<br>
+
+Ce que ça implique très concrètement :
+
+- vous ne possédez rien, donc vous n'immobilisez pas d'argent au départ ;
+- vous payez à l'usage, une dépense de fonctionnement qui suit votre activité ;
+- la capacité disponible dépasse largement ce dont vous aurez jamais besoin ;
+- l'exploitation du matériel — pannes de disque, mises à jour du _firmware_,
+  climatisation — ne vous concerne plus du tout.
+
+<br>
+
+En face, deux contreparties déjà évoquées : une facture difficile à prévoir, et
+une dépendance qui s'installe service après service. C'est malgré tout le choix
+par défaut pour la très grande majorité des projets. Mais tout le monde ne peut
+pas s'en contenter, et c'est là qu'intervient le modèle suivant.
+
+---
+
+## Le cloud privé = dédié, à une seule organisation
+
+Le cloud privé, c'est **la même mécanique — libre-service, API, élasticité —
+mais sur une infrastructure réservée à une seule organisation**. Personne
+d'autre ne tourne sur ces machines.
+
+<br>
+
+Attention, deux formes très différentes se cachent derrière le même mot :
+
+- **le cloud privé interne** : votre organisation achète ses serveurs, les
+  installe dans ses propres locaux et fait tourner par-dessus une couche de
+  virtualisation qui reproduit l'expérience du cloud. C'est ce qu'on appelle
+  aussi l'*on-premise* ;
+- **le cloud privé hébergé** : un prestataire possède et exploite le matériel,
+  mais le dédie contractuellement à votre seule organisation. Vous ne partagez
+  rien avec ses autres clients.
+
+<br>
+
+Dans les deux cas, le raisonnement financier s'inverse. On s'engage sur une
+capacité **à l'avance**, on l'amortit sur plusieurs années, et la facture ne
+baisse pas quand le trafic baisse. En échange, elle ne dérape pas non plus.
+
+<br>
+
+Les motifs qui poussent au cloud privé sont presque toujours les mêmes :
+
+- **la conformité** : une réglementation ou un contrat impose de savoir
+  précisément où sont les données et qui peut y accéder physiquement ;
+- **la maîtrise** : besoin de matériel spécifique, de performances garanties ou
+  d'un contrôle total sur la pile logicielle ;
+- **l'existant** : un parc de serveurs déjà acheté, déjà amorti, qu'on ne va pas
+  jeter parce qu'une mode est passée.
+
+<br>
+
+Le prix de tout ça, c'est que **l'élasticité redevient limitée**. Vous ne pouvez
+pas dépasser la capacité que vous avez achetée, et vous continuez à payer pour
+celle que vous n'utilisez pas. D'où l'envie, très naturelle, de combiner les
+deux.
+
+---
+
+## Le cloud hybride = les deux, reliés
+
+Le cloud hybride, c'est **un système d'information qui combine du cloud public
+et du cloud privé (ou des serveurs internes), reliés entre eux** pour que les
+applications et les données circulent de l'un à l'autre.
+
+<br>
+
+Le point important est dans le mot « reliés ». Avoir un serveur dans un placard
+et un compte chez un fournisseur ne fait pas de vous un cloud hybride, ça fait
+deux systèmes qui s'ignorent. **L'hybride suppose un lien** : un réseau privé
+entre les deux, une authentification commune, un outillage de déploiement qui
+sait viser les deux côtés.
+
+<br>
+
+Les cas d'usage classiques :
+
+- **les données sensibles restent au chaud, le reste part au public** : la base
+  clients côté privé, le site vitrine et les traitements côté public ;
+- **le débordement** : l'application tourne sur l'infrastructure interne au
+  quotidien, et déborde sur le public les jours de pic. Sans acheter du matériel
+  pour trois jours par an ;
+- **la migration progressive** : on déplace une application à la fois vers le
+  public, et pendant la transition — qui dure souvent des années — les deux
+  mondes cohabitent.
+
+<br>
+
+En contrepartie, l'hybride **cumule la complexité des deux modèles**. Deux
+réseaux à faire dialoguer, deux modèles de sécurité à tenir cohérents, deux
+outillages à maîtriser, et des équipes qui doivent être à l'aise partout. Ce
+n'est pas un compromis gratuit, c'est un choix qui se paie en temps d'équipe.
+
+---
+
+## Et le multicloud, alors ?
+
+C'est la confusion la plus fréquente, et elle vaut la peine d'être levée une
+bonne fois : **le multicloud, ce n'est pas l'hybride**.
+
+<br>
+
+Le multicloud, c'est **utiliser plusieurs fournisseurs publics en même temps**.
+Par exemple le calcul chez l'un, le stockage de fichiers chez un autre, et un
+service d'envoi d'e-mails chez un troisième. Tout est public, il y a juste
+plusieurs prestataires.
+
+<br>
+
+Les deux notions sont indépendantes, et se croisent librement :
+
+- public seul → un fournisseur, rien d'autre ;
+- **multicloud** → plusieurs fournisseurs publics, aucun privé ;
+- **hybride** → du public et du privé, reliés ;
+- hybride et multicloud → du privé, plus plusieurs fournisseurs publics.
+
+<br>
+
+On se met au multicloud pour deux raisons, généralement : **réduire la
+dépendance** à un fournisseur unique, ou **aller chercher chez chacun le service
+qu'il fait le mieux**. Le coût, lui, est immédiat : autant de facturations, de
+consoles, de modèles de sécurité et de vocabulaires à connaître que de
+fournisseurs.
+
+Mon conseil : **ne partez jamais en multicloud « pour la résilience » sans avoir
+mesuré ce que ça coûte en complexité**. Dans la plupart des cas, bien répartir
+son application sur plusieurs zones d'un même fournisseur apporte l'essentiel du
+bénéfice pour une fraction de l'effort.
+
+---
+
+## Tableau récapitulatif
+
+Pour y voir clair en un coup d'œil :
+
+|                               | Cloud public               | Cloud privé                     | Cloud hybride             |
+| ----------------------------- | -------------------------- | ------------------------------- | ------------------------- |
+| **Propriété du matériel**     | Le fournisseur             | Votre organisation              | Les deux                  |
+| **Mutualisation**             | Partagé entre clients      | Dédié                           | Selon la partie           |
+| **Modèle de coût**            | À l'usage (fonctionnement) | Investissement + amortissement  | Les deux                  |
+| **Élasticité**                | ✅ Quasi illimitée         | ❌ Bornée à la capacité achetée | ✅ Sur la partie publique |
+| **Maîtrise de l'emplacement** | ❌ Cadrée par les régions  | ✅ Totale                       | ✅ Sur la partie privée   |
+| **Complexité**                | Faible                     | Élevée                          | La plus élevée            |
+
+<br>
+
+Une lecture rapide de ce tableau suffit à comprendre pourquoi le public s'est
+imposé : c'est la seule colonne où la complexité est faible et l'élasticité
+totale. Les deux autres se choisissent quand une contrainte l'impose.
+
+---
+
+## Alors, lequel choisir ?
+
+Comme souvent, la bonne réponse dépend surtout de votre point de départ. Trois
+situations couvrent la grande majorité des cas.
+
+<br>
+
+**Vous démarrez un produit, sans existant.** Allez au **cloud public**, sans
+hésiter. Vous n'avez ni le temps ni les moyens d'exploiter du matériel, et votre
+charge est imprévisible. Prenez simplement l'habitude de préférer les briques
+standards — une base PostgreSQL managée plutôt qu'une base propriétaire — pour
+garder vos options ouvertes.
+
+<br>
+
+**Vous manipulez des données de santé, bancaires ou classifiées.** La contrainte
+réglementaire décide à votre place, et en amont du choix technique : ce sera du
+**cloud privé** ou du **public qualifié** sur une offre certifiée. La question à
+poser en premier n'est pas « quelle technologie ? » mais « quelle qualification
+exige mon secteur ? ».
+
+<br>
+
+**Vous avez un parc de serveurs déjà amorti.** L'**hybride** est alors moins un
+choix qu'un état de fait, celui par lequel passe toute migration un peu
+sérieuse. Le piège est d'y rester par défaut : il coûte cher en complexité, il
+mérite d'être une étape avec une date de fin.
+
+---
+
+## Astuce bonus - L'hybride n'est pas une étape obligatoire
+
+On présente souvent ces trois modèles comme une progression : on commencerait en
+privé, on passerait par l'hybride, et on finirait en public. C'est une histoire
+commerciale commode, pas une trajectoire technique. Dans les faits, **la plupart
+des projets récents sont partis directement en public et n'en sont jamais
+sortis** : sans parc à migrer, pas de phase hybride.
+
+<br>
+
+Le mouvement inverse existe aussi, et il a un nom : le **repatriement**. Des
+entreprises dont la charge est devenue stable constatent qu'elles paient
+l'élasticité sans plus jamais s'en servir, et redescendent tout ou partie de
+leur infrastructure sur du matériel dédié.
+
+<br>
+
+Ce qu'il faut en retenir : **ces trois modèles ne sont pas des niveaux de
+maturité, ce sont des réponses à des contraintes différentes**. Le bon réflexe
+n'est pas de progresser dans une échelle, c'est de vérifier de temps en temps
+que la contrainte qui a motivé votre choix tient toujours.
+
+<hr>
+
+Et voilà, vous ne devriez plus jamais les confondre ! Pour résumer en une
+phrase : **le public est mutualisé chez un fournisseur, le privé est dédié à une
+organisation, l'hybride relie les deux — et le multicloud, c'est simplement
+plusieurs fournisseurs publics**.
+
+Dans la suite de cette série, on descendra d'un cran dans la technique avec les
+modèles de service, ce fameux trio IaaS, PaaS et SaaS qui décrit non plus _chez
+qui_ ça tourne, mais _jusqu'où_ le fournisseur s'occupe de votre pile. Restez
+dans le coin 😉.
+
+D'ici là, je vous invite :
+
+- [à relire la fiche sur le cloud public](/drafts/comprendre-le-cloud-public) si
+  le vocabulaire de base est encore frais ;
+- [à (re)commencer le cours sur Docker et Docker Compose](/cours/docker-et-docker-compose/),
+  parce que le conteneur reste le format qui vous rendra ces choix réversibles.
+
+## Ressources
+
+- [The NIST Definition of Cloud Computing (SP 800-145)](https://csrc.nist.gov/pubs/sp/800/145/final)
+- [Le référentiel SecNumCloud de l'ANSSI](https://cyber.gouv.fr/produits-services-qualifies)
+- [Hybrid cloud, la documentation de Google Cloud](https://cloud.google.com/learn/what-is-hybrid-cloud)
+- [Le glossaire Cloud Native de la CNCF, en français](https://glossary.cncf.io/fr/)

--- a/src/pages/fiches/decouvrir-docker-swarm.md
+++ b/src/pages/fiches/decouvrir-docker-swarm.md
@@ -18,6 +18,7 @@ serie: docker
 tags:
   - Orchestration
   - Production
+  - Cloud
 level: Avancé
 publishedDate: 07/23/2026
 ---

--- a/src/pages/fiches/deployer-image-docker-github-actions.md
+++ b/src/pages/fiches/deployer-image-docker-github-actions.md
@@ -16,6 +16,10 @@ imgSrc: /images/cheatsheets/deployer-image-docker-github-actions.webp
 author: Thomas
 kind: Fiche technique
 serie: cicd
+tags:
+  - Image
+  - Production
+  - Cloud
 level: Intermédiaire
 publishedDate: 07/09/2026
 ---


### PR DESCRIPTION
# Things to check before merging:

- **Did you update the changelog?** Oui — une entrée `in-progress` dans
  `src/content/changelog/2026-07.yaml`. Pas d'entrée `done` : rien n'est publié.
- **Did you link GH issues using the Closes directive?** Non, ce lot ne correspond
  à aucune issue ouverte. Il exécute le cadrage de `docs/cluster-cloud-public.md`.

---

## Ce que fait cette PR

Premier lot de rédaction du cluster cloud, cadré mais resté vide jusqu'ici. Deux
fiches, **posées dans `src/pages/drafts/`** en attendant leurs visuels :

| Fiche                                   | level    | Rôle                |
| --------------------------------------- | -------- | ------------------- |
| `comprendre-le-cloud-public`            | Débutant | Le pilier           |
| `difference-cloud-public-prive-hybride` | Débutant | Le comparatif (SEO) |

Les deux portent `serie: cloud`, `tags: Cloud, Production`, un bloc `faq` de trois
questions, et se citent mutuellement en `/drafts/<slug>` — jamais en
`/fiches/<slug>`, qui serait un 404 tant qu'elles ne sont pas publiées.

Elles apparaissent dans `/drafts/`, avec le libellé de rayon « Cloud public ». Le
rayon sur `/fiches/`, lui, n'apparaîtra qu'à la publication.

## Préparation du maillage, sans lien vers un brouillon

`deployer-image-docker-github-actions` n'avait aucun champ `tags` : il gagne
`Image, Production, Cloud`. `decouvrir-docker-swarm` gagne `Cloud`. De quoi laisser
le scoring de `relatedContent` (`serie` +3, `tag` partagé +1) rapprocher les deux
séries le jour où les fiches sortiront.

**Pas de rétro-lien en revanche.** Le brief les faisait pointer vers la fiche-pont
`deployer-conteneur-docker-dans-le-cloud`, pas encore écrite. Et les faire viser
`/drafts/` enverrait deux fiches publiées et indexées vers des pages inachevées,
avec un retour de lien à ne pas oublier — ce qu'on oublie justement
(`articles/decouvrir-pico-8.md` pointe encore vers `/drafts/prendre-en-main-pico-8`,
publiée depuis). Ils seront posés au moment de publier.

## Deux écarts au brief, assumés

- **Vouvoiement.** Le cadrage disait « tutoiement », mais les fiches publiées
  vouvoient sans exception. Les deux nouvelles fiches suivent l'usage réel, et le
  brief a été corrigé.
- **Espaces insécables.** Absentes des fiches existantes, mais prescrites par le
  skill `typo-francaise` et déjà appliquées aux documents de cadrage.

## Vérification

- `npm run check` — 0 erreur, 0 avertissement ;
- `npm test` — 48 tests au vert ;
- `npm run prettier:check` — au vert ;
- rendu contrôlé sur `npm run dev` : `/drafts/` liste bien les deux fiches, les
  deux pages se rendent avec leur FAQ et un `noindex`, et `/fiches/` n'affiche
  aucun rayon Cloud public ;
- liens internes contrôlés un à un : aucun `/fiches/<slug>` ne vise un fichier de
  `src/pages/drafts/`.

## ⚠️ Reste à faire avant de publier

Les deux visuels ne sont pas produits :

- `raw/cheatsheets/comprendre-le-cloud-public.png`
- `raw/cheatsheets/difference-cloud-public-prive-hybride.png`

puis `npm run optimize-images`. Une fois les `.webp` en place, il restera à
`git mv` les deux fiches vers `src/pages/fiches/`, repasser leurs liens croisés en
`/fiches/<slug>`, poser les deux rétro-liens et passer le changelog en `done`.