### PR TITLE
Publie la fiche « Créer un premier jeu simple avec PICO-8 »

### DIFF
--- a/docs/calendrier-editorial.md
+++ b/docs/calendrier-editorial.md
@@ -85,6 +85,29 @@ en production ».
 | Décembre     | Article | Le cloud public coûte-t-il vraiment moins cher ?            | à faire |
 | Janvier 2027 | Article | Cloud souverain : de quoi parle-t-on vraiment ?             | à faire |
 
+## Série Game dev — PICO-8
+
+Série ouverte en juin 2026, hors calendrier mensuel (elle vient en plus des
+publications prévues, pas à leur place). Rayon `gamedev` sur `/fiches/`.
+
+| Contenu                                 | Type    | Status                            |
+| --------------------------------------- | ------- | --------------------------------- |
+| Découvrir PICO-8                        | Article | **DONE** (juin 2026)              |
+| Comment prendre en main PICO-8 ?        | Fiche   | **DONE** (juin 2026)              |
+| PICO-8 ou Pygame ?                      | Article | **DONE** (juillet 2026)           |
+| Créer un premier jeu simple avec PICO-8 | Fiche   | **DONE** (août 2026)              |
+| Les 10 jeux PICO-8 les plus connus      | Article | brouillon — visuel manquant       |
+| Cours « créer un jeu avec PICO-8 »      | Cours   | promis au manifeste, non planifié |
+
+Deux points à trancher :
+
+- le brouillon `src/pages/drafts/top-10-jeux-pico-8.md` est rédigé, il n'attend
+  que son visuel de une (`raw/articles/top-10-jeux-pico-8.png`), un
+  `serie: gamedev` et une date ;
+- `src/pages/manifeste.astro` annonce « un cours de création de jeux vidéo avec
+  PICO-8 ». Cet engagement n'apparaît nulle part ailleurs : soit on le planifie,
+  soit on le retire du manifeste.
+
 ## Le Recap
 
 | Mois      | Objectif                          | status     |

--- a/src/content/changelog/2026-08.yaml
+++ b/src/content/changelog/2026-08.yaml
@@ -1,0 +1,17 @@
+month: Août
+year: 2026
+order: 8
+tasks:
+  - kind: done
+    keep: true
+    content: |-
+      Nouvelle fiche technique : <a href="/fiches/premier-jeu-simple-pico-8" target="_blank">créer un premier jeu simple avec PICO-8</a>. Un vrai petit jeu de bout en bout — déplacer un personnage, faire apparaître des pièces, compter les points — avec tout le code Lua commenté, étape par étape.
+  - kind: fix
+    content: |-
+      Réparé les liens internes des pages PICO-8 : plusieurs pointaient encore vers des brouillons. Le parcours découverte → prise en main → premier jeu se suit maintenant d'un bout à l'autre.
+  - kind: done
+    content: |-
+      Rangement du rayon Game dev : j'ai posé les séries et les tags qui manquaient sur les contenus PICO-8 et Pygame. De quoi faire enfin tourner les recommandations de fin de page entre eux.
+  - kind: in-progress
+    content: |-
+      Il me reste un article PICO-8 en brouillon, un top 10 des jeux les plus connus de la console. Il n'attend plus que son illustration.

--- a/src/pages/articles/decouvrir-pico-8.md
+++ b/src/pages/articles/decouvrir-pico-8.md
@@ -256,15 +256,13 @@ PICO-8.
 bon moment**. L'outil a quelque chose d'addictif. Il permet d'avoir très
 rapidement d'un prototype jouable.
 
-<!--
 Du coup, je compte bien creuser le sujet ici sur NX. Si vous voulez aller plus
 loin tout de suite, j'ai préparé deux fiches techniques pour démarrer pas à pas
-: [comment prendre en main PICO-8](/drafts/prendre-en-main-pico-8) (installation
+: [comment prendre en main PICO-8](/fiches/prendre-en-main-pico-8) (installation
 et premiers pas), puis
-[créer un premier jeu simple](/drafts/premier-jeu-simple-pico-8). Et si vous
+[créer un premier jeu simple](/fiches/premier-jeu-simple-pico-8). Et si vous
 hésitez encore avec un autre outil, j'ai aussi comparé
-[PICO-8 et Pygame](/drafts/pico-8-ou-pygame).
--->
+[PICO-8 et Pygame](/articles/pico-8-ou-pygame).
 
 Je m'apprête également à participer à une nouvelle game jam :
 [la Retro Recreation Jam](https://itch.io/jam/retro-recreation-2026). Elle

--- a/src/pages/articles/pico-8-ou-pygame.md
+++ b/src/pages/articles/pico-8-ou-pygame.md
@@ -11,6 +11,7 @@ imgAlt: Deux manettes rétro face à face, l'une PICO-8 l'autre Python, pixel ar
 imgSrc: /images/articles/pico-8-ou-pygame.webp
 
 kind: Articles
+serie: gamedev
 author: Thomas
 draft: false
 publishedDate: 07/20/2026
@@ -180,8 +181,8 @@ l'autre.
 Quel que soit votre choix, j'ai de quoi vous lancer pas à pas :
 
 - Côté PICO-8 : [découvrir l'outil](/articles/decouvrir-pico-8), puis
-  [le prendre en main](/drafts/prendre-en-main-pico-8) et enfin
-  [créer un premier jeu simple](/drafts/premier-jeu-simple-pico-8).
+  [le prendre en main](/fiches/prendre-en-main-pico-8) et enfin
+  [créer un premier jeu simple](/fiches/premier-jeu-simple-pico-8).
 - Côté Pygame : [comment bien débuter avec Pygame](/fiches/intro-a-pygame).
 
 Quoi qu'il arrive, le meilleur outil reste celui avec lequel vous finissez vos

--- a/src/pages/fiches/intro-a-pygame.md
+++ b/src/pages/fiches/intro-a-pygame.md
@@ -15,6 +15,11 @@ kind: Fiche technique
 serie: gamedev
 level: Débutant
 publishedDate: 03/07/2026
+
+tags:
+  - Game dev
+  - Pygame
+  - Python
 ---
 
 Si vous avez lu [mon bilan](/articles/review-nx-2025) ou mes

--- a/src/pages/fiches/premier-jeu-simple-pico-8.md
+++ b/src/pages/fiches/premier-jeu-simple-pico-8.md
@@ -14,8 +14,14 @@ imgSrc: /images/cheatsheets/premier-jeu-simple-pico-8.webp
 
 author: Thomas
 kind: Fiche technique
+serie: gamedev
 level: Débutant
-publishedDate: 06/17/2026
+publishedDate: 08/02/2026
+
+tags:
+  - Game dev
+  - PICO-8
+  - Lua
 
 faq:
   - question: Faut-il déjà savoir coder pour faire un jeu PICO-8 ?
@@ -53,7 +59,7 @@ howTo:
 ---
 
 Dans la fiche précédente, on a vu
-[comment prendre en main PICO-8](/drafts/prendre-en-main-pico-8) : l'installer,
+[comment prendre en main PICO-8](/fiches/prendre-en-main-pico-8) : l'installer,
 naviguer entre les éditeurs et lancer une cartouche. Mais un cercle qui bouge
 tout seul, ce n'est pas encore un jeu.
 
@@ -284,7 +290,7 @@ de pistes s'ouvrent pour vous entraîner :
 
 Si vous découvrez tout juste l'outil, (re)lisez d'abord
 [l'article de découverte de PICO-8](/articles/decouvrir-pico-8) et la fiche
-[prendre en main PICO-8](/drafts/prendre-en-main-pico-8). Et si vous venez
+[prendre en main PICO-8](/fiches/prendre-en-main-pico-8). Et si vous venez
 plutôt de Python, jetez un œil à [ma fiche sur Pygame](/fiches/intro-a-pygame) :
 vous retrouverez exactement le même pattern update/draw.
 

--- a/src/pages/fiches/prendre-en-main-pico-8.md
+++ b/src/pages/fiches/prendre-en-main-pico-8.md
@@ -18,6 +18,10 @@ serie: gamedev
 level: Débutant
 publishedDate: 06/23/2026
 
+tags:
+  - Game dev
+  - PICO-8
+
 faq:
   - question: Comment installer PICO-8 ?
     answer:
@@ -268,7 +272,7 @@ et lancer une cartouche. La prochaine étape logique, c'est de transformer ce
 cercle qui bouge tout seul en un vrai petit jeu où **vous** contrôlez l'action.
 
 C'est exactement le programme de la fiche suivante :
-[créer un premier jeu simple avec PICO-8](/drafts/premier-jeu-simple-pico-8). On
+[créer un premier jeu simple avec PICO-8](/fiches/premier-jeu-simple-pico-8). On
 y gère les entrées clavier, on affiche un score et on ramasse des objets.
 
 ## Ressources


### PR DESCRIPTION
Quatrième pièce de la série Game dev, restée en brouillon alors qu'elle
était rédigée de bout en bout. Elle ferme le parcours découverte → prise
en main → premier jeu, que les trois contenus PICO-8 publiés citaient
déjà comme suite logique.

- passe la fiche de src/pages/drafts/ à src/pages/fiches/, avec
  serie: gamedev, des tags et une date d'août ;
- répare les liens internes qui pointaient encore vers /drafts/ (un 404
  réel sur pico-8-ou-pygame) et rouvre le paragraphe de renvoi laissé en
  commentaire dans decouvrir-pico-8, qui attendait cette publication ;
- pose les serie et tags manquants sur le rayon Game dev, pour que le
  bloc « À lire ensuite » relie enfin fiches et articles ;
- documente la série dans le calendrier éditorial et ajoute le changelog
  d'août 2026.

Le visuel de une (/images/cheatsheets/premier-jeu-simple-pico-8.webp)
reste à produire : déposer le PNG dans raw/cheatsheets/ puis lancer
npm run optimize-images.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013UsrwMo4utJrsLp8CmWdJG