### PR TITLE
Replace draft field with /drafts directory structure

### DIFF
--- a/NEXT_FEATURES.md
+++ b/NEXT_FEATURES.md
@@ -30,12 +30,10 @@ ajouter**.
 **Frontmatter existant à respecter** (ne PAS changer le format) :
 
 - Articles :
-  `title, description, imgAlt, imgSrc, kind (="Articles"), author, draft, publishedDate`
+  `title, description, imgAlt, imgSrc, kind (="Articles"), author, publishedDate`
   — `publishedDate` est au format **`MM/DD/YYYY`** (string), parsé partout via
   `new Date()`. Garder `z.string()`, **ne pas** passer en `z.date()`.
 - Fiches : idem + `level` (ex. `"Intermédiaire"`), `kind = "Fiche technique"`.
-  `draft` doit être **optionnel avec `.default(false)`** (les fiches n'ont pas
-  toutes ce champ).
 
 **À créer**
 
@@ -46,9 +44,8 @@ ajouter**.
   `lang: z.enum(["fr","en"]).default("fr")` (évite de re-toucher le schéma en
   Phase 2 et 5).
 - `src/pages/articles/[slug].astro` et `src/pages/fiches/[slug].astro` :
-  `getStaticPaths()` → `getCollection(...)`, filtrer les drafts en prod
-  (`import.meta.env.PROD`), `params.slug = entry.id` (l'`id` = nom de fichier
-  sans extension ⇒ URL identique). Rendu via
+  `getStaticPaths()` → `getCollection(...)`, `params.slug = entry.id` (l'`id` =
+  nom de fichier sans extension ⇒ URL identique). Rendu via
   `const { Content, headings } = await render(entry)`, enveloppé dans les
   layouts existants `BlogPostLayout.astro` / `CheatSheetsLayout.astro` (props
   `{ frontmatter: entry.data, headings }`) — **layouts réutilisés tels quels**.
@@ -68,8 +65,8 @@ ajouter**.
 - `src/pages/rss.xml.js` (**risque le plus élevé**) : `pagesGlobToRssItems` ne
   marche plus. Reconstruire les items via `getCollection` :
   `link: /articles/${id}/` (et `/fiches/`),
-  `pubDate: new Date(data.publishedDate)`, filtrer drafts, trier desc. Comparer
-  `dist/rss.xml` avant/après (les GUID = link, ne doivent pas changer).
+  `pubDate: new Date(data.publishedDate)`, trier desc. Comparer `dist/rss.xml`
+  avant/après (les GUID = link, ne doivent pas changer).
 - `src/types/Article.ts` / `Cheatsheet.ts` : ré-exporter
   `CollectionEntry<"articles">` / `<"fiches">` pour rester aligné avec le
   schéma.
@@ -137,8 +134,8 @@ le header. Note : l'index n'existe qu'après `astro build`.
 1. **Contenu lié** : `src/components/RelatedPosts.astro` +
    `src/utils/getRelated/index.ts` (+ test). Dans `[slug].astro`, calculer les
    entrées proches par `tags` partagés (fallback : plus récentes de la même
-   collection / même `level`), exclure l'article courant et les drafts,
-   réutiliser `Card.astro`.
+   collection / même `level`), exclure l'article courant, réutiliser
+   `Card.astro`.
 2. **Bouton copier le code** : script vanilla `src/scripts/copyCode.ts` (cible
    `pre > code`, `navigator.clipboard`), importé dans les 2 layouts à côté de
    `handleReadingTime()`. Style dans le bloc `is:global` existant. Pas de
@@ -200,7 +197,6 @@ le header. Note : l'index n'existe qu'après `astro build`.
 - **RSS** : reconstruire `link`/`pubDate` identiques sinon re-notification de
   tous les abonnés. Comparer `dist/rss.xml`.
 - **Format de date** : garder `publishedDate` en string `MM/DD/YYYY`.
-- **`draft` optionnel sur les fiches** : `.default(false)` obligatoire.
 - **`astro check` au build** : réconcilier le type `Article` inline de
   `index.astro` et `src/types/*.ts` avec le schéma.
 

--- a/docs/cluster-cloud-public.md
+++ b/docs/cluster-cloud-public.md
@@ -28,7 +28,7 @@ matter `layout`, `title`, `description`, `imgAlt`, `imgSrc`, `author`,
 `kind: Fiche technique`, **`serie: cloud`**, `level`, `publishedDate`
 (MM/DD/YYYY), plus un bloc `faq`. Un article = un `.md` dans
 `src/pages/articles/<slug>.md`, `kind: Articles`, `format: reflexion`,
-**`serie: cloud`**, `draft`, `tags`.
+**`serie: cloud`**, `tags`.
 
 Le champ `serie: cloud` est **indispensable** pour apparaître dans le rayon
 Cloud public de `/fiches/` (`src/data/series.ts`) et alimenter le bloc « À lire

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -57,17 +57,21 @@ const formattedDate = publishedDate
   : "";
 const currentUrl = Astro.url.pathname;
 
+// Les brouillons vivent sous /drafts : déjà hors sitemap et bloqués par
+// robots.txt, on ajoute le noindex pour les URLs découvertes par un lien.
+const isDraft = currentUrl.startsWith("/drafts");
+
 // Le kicker « À la une » n'est affiché que sur le dernier article publié ;
 // les autres articles affichent seulement leur `kind` (ex. « Articles »).
 const normalize = (path: string) => path.replace(/\/+$/, "");
 const allArticles = Object.values(
   import.meta.glob("../pages/articles/*.md", { eager: true }),
 ) as {
-  frontmatter: { draft?: boolean; publishedDate: string };
+  frontmatter: { publishedDate: string };
   url?: string;
 }[];
 const latest = allArticles
-  .filter((article) => !article.frontmatter.draft && article.url)
+  .filter((article) => article.url)
   .sort(
     (a, b) =>
       new Date(b.frontmatter.publishedDate).getTime() -
@@ -115,6 +119,7 @@ const breadCrumbs: Breadcrumb[] = [
     ? []
     : breadCrumbs}
   schemas={schemas}
+  noindex={isDraft}
 >
   {isArticle && <div class="nx-progress-top" data-progress />}
 

--- a/src/layouts/CheatSheetsLayout.astro
+++ b/src/layouts/CheatSheetsLayout.astro
@@ -57,17 +57,21 @@ const formattedDate = publishedDate
   : "";
 const currentUrl = Astro.url.pathname;
 
+// Les brouillons vivent sous /drafts : déjà hors sitemap et bloqués par
+// robots.txt, on ajoute le noindex pour les URLs découvertes par un lien.
+const isDraft = currentUrl.startsWith("/drafts");
+
 // Le kicker « À la une » n'est affiché que sur la dernière fiche publiée ;
 // les autres affichent seulement leur `kind` (« Fiche technique »).
 const normalize = (path: string) => path.replace(/\/+$/, "");
 const allFiches = Object.values(
   import.meta.glob("../pages/fiches/*.md", { eager: true }),
 ) as {
-  frontmatter: { draft?: boolean; publishedDate: string };
+  frontmatter: { publishedDate: string };
   url?: string;
 }[];
 const latest = allFiches
-  .filter((fiche) => !fiche.frontmatter.draft && fiche.url)
+  .filter((fiche) => fiche.url)
   .sort(
     (a, b) =>
       new Date(b.frontmatter.publishedDate).getTime() -
@@ -130,6 +134,7 @@ const breadCrumbs: Breadcrumb[] = [
   pageType="article"
   title={title}
   schemas={schemas}
+  noindex={isDraft}
 >
   <div class="nx-progress-top" data-progress></div>
 

--- a/src/pages/articles/cahier-de-vacances-2026.md
+++ b/src/pages/articles/cahier-de-vacances-2026.md
@@ -20,7 +20,6 @@ tags:
   - Formation
   - Été
 author: Thomas
-draft: false
 publishedDate: 07/17/2026
 ---
 

--- a/src/pages/articles/decouvrez-les-fiches-techniques.md
+++ b/src/pages/articles/decouvrez-les-fiches-techniques.md
@@ -16,7 +16,6 @@ tags:
   - NX Academy
   - Fiches techniques
 author: Thomas
-draft: false
 publishedDate: 08/24/2024
 ---
 

--- a/src/pages/articles/decouvrir-pico-8.md
+++ b/src/pages/articles/decouvrir-pico-8.md
@@ -16,7 +16,6 @@ kind: Articles
 format: reflexion
 serie: gamedev
 author: Thomas
-draft: false
 publishedDate: 06/17/2026
 
 tags:

--- a/src/pages/articles/devops-affaire-de-chaque-developpeur.md
+++ b/src/pages/articles/devops-affaire-de-chaque-developpeur.md
@@ -17,7 +17,6 @@ kind: Articles
 format: reflexion
 serie: devops
 author: Thomas
-draft: false
 publishedDate: 07/31/2026
 
 tags:

--- a/src/pages/articles/gpt-meileur-ami.md
+++ b/src/pages/articles/gpt-meileur-ami.md
@@ -17,7 +17,6 @@ tags:
   - IA
   - ChatGPT
 author: Thomas
-draft: false
 publishedDate: 02/09/2025
 ---
 

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -61,21 +61,18 @@ const editionOf = (title: string) => {
   return match ? Number(match[1]) : undefined;
 };
 
-const enriched = modules
-  .filter((module) => !module.frontmatter.draft)
-  .map((module) => {
-    const { frontmatter, url } = module;
-    const format = (frontmatter.format ?? "reflexion") as Format;
-    const edition =
-      format === "recap" ? editionOf(frontmatter.title) : undefined;
-    return {
-      ...frontmatter,
-      url: url!,
-      format,
-      edition,
-      read: calculateReadingTime(module.rawContent()),
-    };
-  });
+const enriched = modules.map((module) => {
+  const { frontmatter, url } = module;
+  const format = (frontmatter.format ?? "reflexion") as Format;
+  const edition = format === "recap" ? editionOf(frontmatter.title) : undefined;
+  return {
+    ...frontmatter,
+    url: url!,
+    format,
+    edition,
+    read: calculateReadingTime(module.rawContent()),
+  };
+});
 
 // La série « Le récap » : éditions numérotées, de la plus récente à la plus ancienne.
 const recaps = enriched

--- a/src/pages/articles/le-recap-aout-2025.md
+++ b/src/pages/articles/le-recap-aout-2025.md
@@ -18,7 +18,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 08/29/2025
 ---
 

--- a/src/pages/articles/le-recap-avril-2025.md
+++ b/src/pages/articles/le-recap-avril-2025.md
@@ -16,7 +16,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 04/25/2025
 ---
 

--- a/src/pages/articles/le-recap-juillet-2025.md
+++ b/src/pages/articles/le-recap-juillet-2025.md
@@ -18,7 +18,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 07/25/2025
 ---
 

--- a/src/pages/articles/le-recap-juillet-2026.md
+++ b/src/pages/articles/le-recap-juillet-2026.md
@@ -17,7 +17,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 07/24/2026
 ---
 

--- a/src/pages/articles/le-recap-juin-2025.md
+++ b/src/pages/articles/le-recap-juin-2025.md
@@ -18,7 +18,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 06/27/2025
 ---
 

--- a/src/pages/articles/le-recap-juin-2026.md
+++ b/src/pages/articles/le-recap-juin-2026.md
@@ -16,7 +16,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 06/30/2026
 ---
 

--- a/src/pages/articles/le-recap-mai-2025.md
+++ b/src/pages/articles/le-recap-mai-2025.md
@@ -17,7 +17,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 05/31/2025
 ---
 

--- a/src/pages/articles/le-recap-presentation.md
+++ b/src/pages/articles/le-recap-presentation.md
@@ -19,7 +19,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 04/25/2025
 ---
 

--- a/src/pages/articles/le-recap-septembre-2025.md
+++ b/src/pages/articles/le-recap-septembre-2025.md
@@ -16,7 +16,6 @@ tags:
   - Veille
   - Le Récap
 author: Thomas
-draft: false
 publishedDate: 09/26/2025
 ---
 

--- a/src/pages/articles/le-recap.astro
+++ b/src/pages/articles/le-recap.astro
@@ -42,7 +42,6 @@ const editionOf = (title: string) => {
 const recaps = modules
   .filter(
     (module) =>
-      !module.frontmatter.draft &&
       module.frontmatter.format === "recap" &&
       editionOf(module.frontmatter.title),
   )

--- a/src/pages/articles/le-recap/rss.xml.js
+++ b/src/pages/articles/le-recap/rss.xml.js
@@ -10,7 +10,6 @@ export async function GET(context) {
   const items = modules
     .filter(
       (module) =>
-        !module.frontmatter.draft &&
         module.frontmatter.format === "recap" &&
         /#(\d+)/.test(module.frontmatter.title),
     )

--- a/src/pages/articles/ne-plus-se-dedoubler.md
+++ b/src/pages/articles/ne-plus-se-dedoubler.md
@@ -18,7 +18,6 @@ tags:
   - IA
   - Développeur
 author: Thomas
-draft: false
 publishedDate: 07/14/2026
 ---
 

--- a/src/pages/articles/nx-fait-des-jeux.md
+++ b/src/pages/articles/nx-fait-des-jeux.md
@@ -16,7 +16,6 @@ tags:
   - Game dev
   - Carnet de bord
 author: Thomas
-draft: false
 publishedDate: 04/01/2026
 ---
 

--- a/src/pages/articles/pico-8-ou-pygame.md
+++ b/src/pages/articles/pico-8-ou-pygame.md
@@ -12,7 +12,6 @@ imgSrc: /images/articles/pico-8-ou-pygame.webp
 
 kind: Articles
 author: Thomas
-draft: false
 publishedDate: 07/20/2026
 
 tags:

--- a/src/pages/articles/point-nx-2025.md
+++ b/src/pages/articles/point-nx-2025.md
@@ -16,7 +16,6 @@ tags:
   - NX Academy
   - Bilan
 author: Thomas
-draft: false
 publishedDate: 01/25/2025
 ---
 

--- a/src/pages/articles/profils-ia-developpeur.md
+++ b/src/pages/articles/profils-ia-developpeur.md
@@ -19,7 +19,6 @@ tags:
   - IA
   - Développeur
 author: Thomas
-draft: false
 publishedDate: 03/29/2025
 ---
 

--- a/src/pages/articles/projets-pour-2026.md
+++ b/src/pages/articles/projets-pour-2026.md
@@ -15,7 +15,6 @@ tags:
   - NX Academy
   - Bilan
 author: Thomas
-draft: false
 publishedDate: 01/01/2026
 ---
 

--- a/src/pages/articles/review-nx-2025.md
+++ b/src/pages/articles/review-nx-2025.md
@@ -16,7 +16,6 @@ tags:
   - NX Academy
   - Bilan
 author: Thomas
-draft: false
 publishedDate: 12/27/2025
 ---
 

--- a/src/pages/articles/welcome-v2.md
+++ b/src/pages/articles/welcome-v2.md
@@ -15,7 +15,6 @@ serie: nx
 tags:
   - NX Academy
 author: Thomas
-draft: false
 publishedDate: 03/21/2024
 ---
 

--- a/src/pages/drafts/index.astro
+++ b/src/pages/drafts/index.astro
@@ -1,0 +1,199 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { SERIES } from "../../data/series";
+
+// Le frontmatter des brouillons est hétérogène : ils mêlent articles et fiches,
+// et certains champs (serie, level, visuel) manquent encore. Tout est donc
+// optionnel sauf le strict nécessaire à l'affichage de la liste.
+type Draft = {
+  frontmatter: {
+    title: string;
+    description: string;
+    publishedDate: string;
+    author?: string;
+    kind?: string;
+    level?: string;
+    serie?: string;
+  };
+  url?: string;
+};
+
+// Aucun filtre : tout ce qui vit dans /drafts est un brouillon. Le champ
+// `draft` du frontmatter n'existe plus, c'est le dossier qui fait foi.
+const drafts = (
+  Object.values(import.meta.glob("./*.md", { eager: true })) as Draft[]
+)
+  .filter((draft) => draft.url)
+  .sort(
+    (a, b) =>
+      new Date(b.frontmatter.publishedDate).getTime() -
+      new Date(a.frontmatter.publishedDate).getTime(),
+  );
+
+const frDate = (date: string) => new Date(date).toLocaleDateString("fr-FR");
+
+// La série est stockée par clé (`cicd`) : on affiche son libellé de rayon
+// (« CI/CD »), avec repli sur la clé brute si elle n'est pas encore déclarée.
+const serieLabel = (serie: string) => SERIES[serie]?.label ?? serie;
+
+const title = "Brouillons";
+const description =
+  "Les contenus en cours de rédaction. Page interne, non indexée.";
+---
+
+<BaseLayout title={title} description={description} noindex={true}>
+  <div class="wrapper">
+    <section>
+      <h1>Brouillons</h1>
+      <p class="lead">
+        Les contenus écrits mais pas encore publiés. Ils vivent dans <code
+          >src/pages/drafts/</code
+        > : hors sitemap, hors moteurs de recherche, et invisibles depuis les index
+        du site. Pour publier, déplacez le fichier vers <code
+          >src/pages/articles/</code
+        > ou <code>src/pages/fiches/</code>.
+      </p>
+
+      <p class="count">
+        <b>{drafts.length}</b> brouillon{drafts.length > 1 ? "s" : ""}
+      </p>
+
+      <ul class="list">
+        {
+          drafts.map(({ frontmatter, url }) => (
+            <li>
+              <a href={url}>{frontmatter.title}</a>
+              <p class="meta">
+                <span>{frontmatter.kind ?? "Contenu"}</span>
+                {frontmatter.serie && (
+                  <span>{serieLabel(frontmatter.serie)}</span>
+                )}
+                {frontmatter.level && <span>{frontmatter.level}</span>}
+                <span>{frDate(frontmatter.publishedDate)}</span>
+              </p>
+              <p class="desc">{frontmatter.description}</p>
+            </li>
+          ))
+        }
+      </ul>
+
+      {drafts.length === 0 && <p class="empty">Aucun brouillon en attente.</p>}
+    </section>
+  </div>
+</BaseLayout>
+
+<style>
+  .wrapper {
+    padding-top: 1.5rem;
+    padding-bottom: 3rem;
+  }
+
+  section {
+    width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1100px;
+  }
+
+  h1 {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    color: var(--titleColor);
+    font-size: clamp(2rem, 1.5rem + 1.8vw, 2.6rem);
+    line-height: 1.12;
+    margin: 0 0 1.3rem;
+  }
+
+  .lead {
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    color: var(--textColor);
+    margin: 0 0 2rem;
+    max-width: 70ch;
+  }
+
+  .lead code {
+    font-family: var(--font-mono);
+    background-color: var(--codeBackgroundColor);
+    color: var(--codeTextColor);
+    padding: 0.1em 0.4em;
+    border-radius: var(--radius-sm);
+    font-size: 0.9em;
+  }
+
+  .count {
+    font-size: 0.92rem;
+    color: var(--textColor);
+    border-top: 1px solid var(--borderPrimary);
+    padding-top: 1.2rem;
+    margin: 0;
+  }
+
+  .count b {
+    color: var(--titleColor);
+    font-weight: 600;
+  }
+
+  .list {
+    list-style: none;
+    padding: 0;
+    margin: 1.6rem 0 0;
+    display: grid;
+    gap: 1.8rem;
+  }
+
+  .list li {
+    display: grid;
+    gap: 0.4rem;
+    border-bottom: 1px solid var(--borderPrimary);
+    padding-bottom: 1.6rem;
+  }
+
+  .list li:last-child {
+    border-bottom: 0;
+  }
+
+  .list a {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    font-size: 1.15rem;
+    line-height: 1.3;
+    color: var(--linkColor);
+    text-decoration: none;
+    transition: color var(--transition);
+  }
+
+  .list a:hover {
+    color: var(--linkHoverColor);
+  }
+
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.76rem;
+    color: var(--textColor);
+    margin: 0;
+  }
+
+  /* Séparateur en pastille entre les métadonnées présentes. */
+  .meta span + span::before {
+    content: "·";
+    margin-right: 0.5rem;
+    opacity: 0.6;
+  }
+
+  .desc {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--textColor);
+    margin: 0;
+    max-width: 75ch;
+  }
+
+  .empty {
+    color: var(--textColor);
+    padding: 2rem 0;
+  }
+</style>

--- a/src/pages/drafts/top-10-jeux-pico-8.md
+++ b/src/pages/drafts/top-10-jeux-pico-8.md
@@ -12,7 +12,6 @@ imgSrc: /images/articles/top-10-jeux-pico-8.webp
 
 kind: Articles
 author: Thomas
-draft: true
 publishedDate: 06/17/2026
 
 tags:

--- a/src/pages/fiches/index.astro
+++ b/src/pages/fiches/index.astro
@@ -4,9 +4,9 @@ import type { Cheatsheet } from "../../types/Cheatsheet";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { SERIES } from "../../data/series";
 
-const cheatsheets = (
-  Object.values(import.meta.glob("./*.md", { eager: true })) as Cheatsheet[]
-).filter((cheatsheet) => !cheatsheet.frontmatter.draft);
+const cheatsheets = Object.values(
+  import.meta.glob("./*.md", { eager: true }),
+) as Cheatsheet[];
 
 const LEVELS = ["Débutant", "Intermédiaire", "Avancé"];
 const levelClass = (level: string) =>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,6 @@ type Article = {
     imgSrc: string;
     author: string;
     publishedDate: string;
-    draft: boolean;
     level: string;
   };
   url: string;
@@ -106,11 +105,7 @@ const startHereItems = [
         <div class="cards-wrapper">
           {
             content
-              .filter(
-                (c) =>
-                  !c.frontmatter.draft &&
-                  c.frontmatter.title !== heroContentTitle,
-              )
+              .filter((c) => c.frontmatter.title !== heroContentTitle)
               .sort(
                 (item1, item2) =>
                   new Date(item2.frontmatter.publishedDate).getTime() -

--- a/src/types/Article.ts
+++ b/src/types/Article.ts
@@ -2,7 +2,6 @@ export type Article = {
   frontmatter: {
     author: string;
     description: string;
-    draft: boolean;
     format?: "recap" | "reflexion" | "bilan";
     imgAlt: string;
     imgSrc: string;

--- a/src/types/Cheatsheet.ts
+++ b/src/types/Cheatsheet.ts
@@ -2,7 +2,6 @@ export type Cheatsheet = {
   frontmatter: {
     author: string;
     description: string;
-    draft: boolean;
     imgAlt: string;
     imgSrc: string;
     kind?: string;

--- a/src/utils/relatedContent/index.test.ts
+++ b/src/utils/relatedContent/index.test.ts
@@ -89,15 +89,6 @@ describe("scoreRelated", () => {
     expect(urls).not.toContain("/fiches/clamp");
   });
 
-  it("excludes drafts", () => {
-    const withDraft = [
-      ...pool,
-      makeItem("/fiches/secret", { serie: "gamedev", draft: true }),
-    ];
-    const result = scoreRelated(current, withDraft, 5);
-    expect(result.some((i) => i.url === "/fiches/secret")).toBe(false);
-  });
-
   it("falls back to recency when nothing is relevant, never emptier than limit allows", () => {
     const lonely = makeItem("/articles/seul", { serie: "inconnu" });
     const onlyOthers = [

--- a/src/utils/relatedContent/index.ts
+++ b/src/utils/relatedContent/index.ts
@@ -6,7 +6,6 @@
 // `tags` servent de signal fin pour départager.
 
 export type RelatedFrontmatter = {
-  draft?: boolean;
   title: string;
   imgSrc: string;
   imgAlt: string;
@@ -66,7 +65,7 @@ export function relevanceScore(
 /**
  * Sélectionne les contenus « À lire ensuite » les plus pertinents.
  *
- * - Exclut les brouillons, les items sans URL et la page courante.
+ * - Exclut les items sans URL et la page courante.
  * - Trie par score de pertinence décroissant, puis par date décroissante.
  * - Complète par les contenus les plus récents (préférence au `kind` de la
  *   page courante) si moins de `limit` candidats sont pertinents, afin de ne
@@ -80,10 +79,7 @@ export function scoreRelated(
   const currentUrl = current.url ? normalizeUrl(current.url) : undefined;
 
   const candidates = pool.filter(
-    (item) =>
-      !item.frontmatter.draft &&
-      item.url &&
-      normalizeUrl(item.url) !== currentUrl,
+    (item) => item.url && normalizeUrl(item.url) !== currentUrl,
   );
 
   const scored = candidates


### PR DESCRIPTION
## Description

This PR replaces the `draft` boolean field in frontmatter with a directory-based approach: content is now considered a draft simply by living in `src/pages/drafts/` instead of `src/pages/articles/` or `src/pages/fiches/`.

### Key Changes

1. **New drafts index page** (`src/pages/drafts/index.astro`)
   - Lists all draft content with metadata (kind, series, level, date)
   - Automatically marked with `noindex` to keep drafts out of search engines
   - Displays count and provides guidance on publishing workflow

2. **Removed `draft` field from all content**
   - Deleted `draft: false` from all published articles and fiches
   - Deleted `draft: true` from draft content (now identified by location)
   - Simplified type definitions in `Article.ts` and `Cheatsheet.ts`

3. **Updated filtering logic**
   - Removed all `.filter((item) => !item.frontmatter.draft)` checks
   - Content is now filtered by directory location, not metadata
   - Simplified `src/pages/articles/index.astro` and `src/pages/fiches/index.astro`

4. **Layout improvements**
   - Added `isDraft` detection in `BlogPostLayout.astro` and `CheatSheetsLayout.astro`
   - Draft content automatically gets `noindex` meta tag for extra protection
   - Removed draft filtering from "latest article/fiche" logic

5. **Related content filtering**
   - Removed draft exclusion from `scoreRelated()` utility
   - Updated test suite to remove draft-specific test case
   - Simplified `RelatedFrontmatter` type

6. **Documentation updates**
   - Updated `NEXT_FEATURES.md` to reflect new draft handling approach
   - Updated `docs/cluster-cloud-public.md` to remove draft field references

### Benefits

- **Clearer intent**: Directory structure makes draft status obvious at a glance
- **Simpler publishing**: Move file from `/drafts/` to `/articles/` or `/fiches/` to publish
- **Reduced metadata**: One less field to manage in frontmatter
- **Better organization**: Drafts are physically separated from published content

### Testing

- Existing tests updated to remove draft-specific assertions
- Draft content remains excluded from indexes, RSS, and search
- Draft URLs still accessible but marked with `noindex` for defense-in-depth

https://claude.ai/code/session_01Ur5RVZU2PSp9Ey2wQ9cjAE